### PR TITLE
Fix for hash routing | sas | #362

### DIFF
--- a/packages/design-system/src/main.ts
+++ b/packages/design-system/src/main.ts
@@ -2,10 +2,18 @@ import Vue from 'vue';
 import App from './App.vue';
 import router from './router';
 import store from './store';
-import { defineCustomElements, applyPolyfills } from '@porsche-ui/ui-kit-js/loader';
+import {defineCustomElements, applyPolyfills} from '@porsche-ui/ui-kit-js/loader';
 import Playground from '@/components/Playground.vue';
 import ColorBadge from '@/components/ColorBadge.vue';
 import '@porsche-ui/ui-kit-js/dist/porsche-ui-kit/porsche-ui-kit.css';
+
+/**
+ * TODO: Bugfix for macOS + Slack automatic hash escaping (e.g. Slack on macOS manipulates following url
+ * from https://ui.porsche.com/latest/#/web/components/basic/marque#code
+ * to https://ui.porsche.com/latest/#/web/components/basic/marque%23code
+ * which causes 404)
+ */
+window.location.hash = window.location.hash.replace('%23', '#');
 
 Vue.config.productionTip = false;
 Vue.config.ignoredElements = [/p-\w*/];


### PR DESCRIPTION
**References**  
- Closes #362 
- [Documentaion Preview](https://porscheui.github.io/porsche-ui-kit/issue/362/#/web/components/basic/marque%23code)

**Scope**  
Hashed link can't be opend when send via Slack on macOS or iOS.