### PR TITLE
Issue/360

### DIFF
--- a/packages/ui-kit-js/CHANGELOG.md
+++ b/packages/ui-kit-js/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## NOT RELEASED YET
 
 ### Change
-* Remove stencil collection and unused entry points from build artifact
+* Remove stencil collection
 
 ## [1.0.0-alpha.7] (2019-11-05)
 

--- a/packages/ui-kit-js/package.json
+++ b/packages/ui-kit-js/package.json
@@ -3,6 +3,10 @@
   "version": "1.0.0-alpha.7",
   "scope": "@porsche-ui",
   "description": "Porsche UI Web Components",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "es2015": "dist/esm/index.mjs",
+  "es2017": "dist/esm/index.mjs",
   "types": "dist/types/components.d.ts",
   "files": [
     "dist/",


### PR DESCRIPTION
**References**  
- Closes #360

**Scope**  
* Remove stencil collection files from build artifact to prevent other teams to accidently using it instead of our pre-bundled components.
* Remove unused empty enty points from package.json