### PR TITLE
Fix code examples for events in Angular / React

### DIFF
--- a/packages/storefront/src/components/CodeBlock.vue
+++ b/packages/storefront/src/components/CodeBlock.vue
@@ -107,20 +107,24 @@ export default class CodeBlock extends Vue {
     return (
       markup
         // transform to event binding syntax
-        .replace(/(\son.*?)="(.*?)"/g, (m, $key, $value) => {
-          return `(${$key.substring(3)})="${$value}"`;
+        .replace(/\s(on.+?)="(.*?)"/g, (m, $key, $value) => {
+          return ` (${$key.substring(2)})="${$value}"`;
         })
-        // transform all keys of obect values to camel case and surround them in brackets
-        .replace(/(\S+)="{(.*?)}"/g, (m, $key, $value) => {
-          return `[${camelCase($key)}]="{${$value}}"`;
+        // transform all keys of object values to camel case and surround them in brackets
+        .replace(/\s(\S+)="{(.*?)}"/g, (m, $key, $value) => {
+          return ` [${camelCase($key)}]="{${$value}}"`;
         })
         // transform all other keys to camel case, surround them in brackets and surround all values with ''
-        .replace(/(\S*[a-zA-Z-]+)="(\D\w.*?)"/g, (m, $key, $value) => {
-          return `[${camelCase($key)}]="'${$value}'"`;
+        .replace(/\s(\S*[a-z-]+)="(\D\w.*?)"/g, (m, $key, $value) => {
+          return ` [${camelCase($key)}]="'${$value}'"`;
+        })
+        // transform all keys to camel case which have digits as a value
+        .replace(/\s(\S*[a-z-]+)="(\d.*?)"/g, (m, $key, $value) => {
+          return ` [${camelCase($key)}]="${$value}"`;
         })
         // remove single quotes from boolean values
-        .replace(/(\S*\[*\w])="'((true|false).*?)'"/g, (m, $key, $value) => {
-          return `${$key}="${$value}"`;
+        .replace(/\s\[(\S+)]="'(true|false)'"/g, (m, $key, $value) => {
+          return ` [${camelCase($key)}]="${$value}"`;
         })
 
     );
@@ -130,24 +134,28 @@ export default class CodeBlock extends Vue {
     return (
       markup
         // remove quotes from object values but add double brackets and camelCase
-        .replace(/(\S+)="{(.*?)}"/g, (m, $key, $value) => {
-          return `${camelCase($key)}={{${$value}}}`;
+        .replace(/\s(\S+)="{(.*?)}"/g, (m, $key, $value) => {
+          return ` ${camelCase($key)}={{${$value}}}`;
         })
         // transform all standard attributes to camel case and add brackets
-        .replace(/(\S+)="(.*?)"/g, (m, $key, $value) => {
-          return `${camelCase($key)}={"${$value}"}`;
+        .replace(/\s(\S+)="(.*?)"/g, (m, $key, $value) => {
+          return ` ${camelCase($key)}={"${$value}"}`;
         })
         // transform class attribute to JSX compatible one
-        .replace(/class={"(.*?)"}/g, (m, $value) => {
-          return `className={"${$value}"}`;
+        .replace(/\sclass={"(.*?)"}/g, (m, $value) => {
+          return ` className={"${$value}"}`;
         })
         // transform to camelCase event binding syntax
-        .replace(/(\son.*?)={"(.*?)"}/g, (m, $key, $value) => {
-          return `${$key.substring(0,3)+$key.substring(3,4).toUpperCase()+$key.substring(4)}={() => {${$value}}}`;
+        .replace(/\s(on.+?)={"(.*?)"}/g, (m, $key, $value) => {
+          return ` on${upperFirst($key.substring(2))}={() => {${$value}}}`;
         })
         // transform boolean
-        .replace(/(\S+)={"(true|false)"}/g, (m, $key, $value) => {
-          return `${$key}={${$value}}`;
+        .replace(/\s(\S+)={"(true|false)"}/g, (m, $key, $value) => {
+          return ` ${$key}={${$value}}`;
+        })
+        // transform all keys to camel case which have digits as a value
+        .replace(/\s(\S+)={"(\d.*?)"}/g, (m, $key, $value) => {
+          return ` ${$key}={${$value}}`;
         })
         // transform custom element opening tags to pascal case
         .replace(/<(p-[\w-]+)(.*?)>/g, (m, $tag, $attributes) => {

--- a/packages/storefront/tests/unit/components.code-block.spec.ts
+++ b/packages/storefront/tests/unit/components.code-block.spec.ts
@@ -205,7 +205,7 @@ describe('CodeBlock.vue', () => {
       stubs: ['p-text'],
       propsData: {
         markup:
-          `<p-some-tag some-attribute="some value" attribute="some value" class="some-class" another-attribute="{ bar: 'foo' }" onclick="alert('click'); return false;">
+          `<p-some-tag some-attribute="some value" attribute="some value" class="some-class" another-attribute="{ bar: 'foo' }" onclick="alert('click'); return false;" digit-attribute="6" boolean-attribute="true">
   <span>some text</span>
 </p-some-tag>`
       }
@@ -216,7 +216,7 @@ describe('CodeBlock.vue', () => {
     await tick();
 
     expect(wrapper.find('code').text()).toBe(
-      `<p-some-tag [someAttribute]="'some value'" [attribute]="'some value'" [class]="'some-class'" [anotherAttribute]="{ bar: 'foo' }" (click)="alert('click'); return false;">
+      `<p-some-tag [someAttribute]="'some value'" [attribute]="'some value'" [class]="'some-class'" [anotherAttribute]="{ bar: 'foo' }" (click)="alert('click'); return false;" [digitAttribute]="6" [booleanAttribute]="true">
   <span>some text</span>
 </p-some-tag>`
     );
@@ -227,7 +227,7 @@ describe('CodeBlock.vue', () => {
       stubs: ['p-text'],
       propsData: {
         markup:
-          `<p-some-tag some-attribute="some value" attribute="some value" class="some-class" another-attribute="{ bar: 'foo' }" onclick="alert('click'); return false;">
+          `<p-some-tag some-attribute="some value" attribute="some value" class="some-class" another-attribute="{ bar: 'foo' }" onclick="alert('click'); return false;" digit-attribute="6" boolean-attribute="true">
   <span>some text</span>
 </p-some-tag>`
       }
@@ -238,7 +238,7 @@ describe('CodeBlock.vue', () => {
     await tick();
 
     expect(wrapper.find('code').text()).toBe(
-      `<PSomeTag someAttribute={"some value"} attribute={"some value"} className={"some-class"} anotherAttribute={{ bar: 'foo' }} onClick={()=> {alert('click'); return false;}}>
+      `<PSomeTag someAttribute={"some value"} attribute={"some value"} className={"some-class"} anotherAttribute={{ bar: 'foo' }} onClick={()=> {alert('click'); return false;}} digitAttribute={6} booleanAttribute={true}>
   <span>some text</span>
 </PSomeTag>`
     );


### PR DESCRIPTION
**References**  
- Closes #361 
- Documentation Preview: https://designsystem.porsche.com/issue/361/

**Scope**  
Fixes rendering of Code Examples (e.g. Attributes) in Angular and React

