### PR TITLE
fix(components-js): Spinner zooming bug on safari | oh | #976

### DIFF
--- a/packages/components-angular/projects/components-wrapper/CHANGELOG.md
+++ b/packages/components-angular/projects/components-wrapper/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [Unreleased]
 
+### Fixed
+- `Spinner` zooming bug on Safari
+
 ### [1.5.5] - 2020-09-11
 
 ### [1.5.5-rc.0] - 2020-09-07

--- a/packages/components-js/CHANGELOG.md
+++ b/packages/components-js/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [Unreleased]
 
+### Fixed
+- `Spinner` zooming bug on Safari
+
 ### [1.5.5] - 2020-09-11
 
 ### [1.5.5-rc.0] - 2020-09-07

--- a/packages/components-js/src/components/feedback/spinner/spinner.scss
+++ b/packages/components-js/src/components/feedback/spinner/spinner.scss
@@ -178,7 +178,7 @@ $p-spinner-size-large: p-px-to-rem(104px);
   }
 
   &__fg {
-    transform-origin: center center;
+    transform-origin: 0 0;
     animation: rotate var(--p-animation-duration__spinner, 2s) linear infinite,
     dash var(--p-animation-duration__spinner, 2s) ease-in-out infinite;
     stroke-dasharray: 40, 200;

--- a/packages/components-js/src/components/feedback/spinner/spinner.tsx
+++ b/packages/components-js/src/components/feedback/spinner/spinner.tsx
@@ -25,9 +25,9 @@ export class Spinner {
 
     return (
       <span class={spinnerClasses} aria-busy="true" aria-live="polite">
-        <svg class={imageClasses} viewBox="0 0 32 32" width="100%" height="100%" role="img" focusable="false">
-          <circle class={bgClasses} cx="50%" cy="50%" r="9" />
-          <circle class={fgClasses} cx="50%" cy="50%" r="9" />
+        <svg class={imageClasses} viewBox="-16 -16 32 32" width="100%" height="100%" focusable="false">
+          <circle class={bgClasses} r="9" />
+          <circle class={fgClasses} r="9" />
         </svg>
       </span>
     );

--- a/packages/components-react/projects/components-wrapper/CHANGELOG.md
+++ b/packages/components-react/projects/components-wrapper/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [Unreleased]
 
+### Fixed
+- `Spinner` zooming bug on Safari
+
 ### [1.5.5] - 2020-09-11
 
 ### [1.5.5-rc.0] - 2020-09-07


### PR DESCRIPTION
**References**  
- Documentation Preview: https://designsystem.porsche.com/issue/976/

**Scope**  
Fixed `Spinner` scaling Bug (on Browser page zoom) in Safari
