### PR TITLE
Issue/1943 Add interaction to `stepper-horizontal-item` in UXPin

### DIFF
--- a/packages/components/scripts/wrapper-generator/UXPinReactWrapperGenerator.ts
+++ b/packages/components/scripts/wrapper-generator/UXPinReactWrapperGenerator.ts
@@ -90,7 +90,7 @@ export class UXPinReactWrapperGenerator extends ReactWrapperGenerator {
     }
 
     // add onClick prop for marque, buttons and links, but not button-group
-    else if (!!component.match(/(button|link|marque|tag-dismissible)(?!-group)/)) {
+    else if (!!component.match(/(button|link|marque|stepper-horizontal-item|tag-dismissible)(?!-group)/)) {
       props = addProp(props, 'onClick?: (e: MouseEvent) => void;');
     }
 


### PR DESCRIPTION
- [X] I have read and accept the
      [Contributor License Agreement](https://github.com/porscheofficial/oss-docs/blob/67c5b24838a293ce7a964884e6005eb71f2b8579/CONTRIBUTOR_LICENSE_AGREEMENT.md)

**References**

Fix #1943 

As mentioned in the [official example](https://designsystem.porsche.com/v2/components/stepper-horizontal/examples#),  designers should be able to add interactions on the stepper items.

> The user should have the opportunity to use the stepper to jump to the previous steps.

**Scope**  

An `onClick` prop translates to an interaction in the UXPin properties panel.

**How to test**

- Run `yarn build:generateWrappers` from `components` package
- Launch UXPin experimental mode from `components-react/projects/uxpin-wrapper`: `yarn start`
- Add a `StepperHorizontal` component to the canvas
- Check that the `onClick` interaction is available
 
![image](https://user-images.githubusercontent.com/5546996/176364971-2100c362-7955-4f7b-9235-0d025f0b6495.png)

