### PR TITLE
Re-render `TextField` if the input `type` changes

### DIFF
--- a/packages/components/src/components/form/text-field-wrapper/text-field-wrapper.tsx
+++ b/packages/components/src/components/form/text-field-wrapper/text-field-wrapper.tsx
@@ -119,7 +119,6 @@ export class TextFieldWrapper {
     this.observeAttributes(); // once initially
 
     observeProperties(this.input, ['type'], () => {
-      console.log('type change!', this.input.type);
       this.initInput();
     });
 
@@ -282,7 +281,7 @@ export class TextFieldWrapper {
     );
   }
 
-  private initInput = () => {
+  private initInput = (): void => {
     this.input = getOnlyChildOfKindHTMLElementOrThrow(
       this.host,
       ['text', 'number', 'email', 'tel', 'search', 'url', 'date', 'time', 'month', 'week', 'password']


### PR DESCRIPTION
### Pull Request Checklist

<!-- Make sure to read and accept the CLA, before you open the pull request: `CONTRIBUTOR_LICENSE_AGREEMENT` -->
<!-- Tick the checkbox in case you accept it (`[x]`) -->

- [x] I have read and accept the [Contributor License Agreement](https://github.com/porscheofficial/oss-docs/blob/67c5b24838a293ce7a964884e6005eb71f2b8579/CONTRIBUTOR_LICENSE_AGREEMENT.md)

#### References

Fix #1989 

#### Scope

The problem described in the issue (the `TextField` not being updated on the screen when its `type` changes) is about the UXPin editor but the root cause seems to be in the component itself.

I have run the Stencil playground and I added a button that changes the `type` of the `input` field, from `text` to `password` and vice versa: nothing happens on the screen, besides the characters in the input being hidden by the browser when the type is `password`.

The reason: No re-render runs when the type changes.

Here is the HTML code I used to check the current behavior and change it:

```html
<!DOCTYPE html>
<html dir="ltr" lang="en">
<head>
  <meta charset="utf-8" />
  <title>Porsche Design System - Playground</title>
  <meta name="viewport" content="width=device-width, initial-scale=1" />
  <link rel="icon" type="image/x-icon" href="favicon.ico" />
  <script nomodule src="build/porsche-design-system.js"></script>
  <script type="module" src="build/porsche-design-system.esm.js"></script>

  <style>
    main {
      max-width: 600px;
    }
  </style>
</head>

<body>
  <p-content-wrapper>
    <header>
      <h1>Porsche Design System - Playground</h1>
    </header>

    <main>
      <p-text-field-wrapper label="Can we change the input type dynamically?">
        <input type="text" id="input" value="My text field content" />
      </p-text-field-wrapper>
      <br />
      <p-button id="btn" variant="primary">Change input type</p-button>
    </main>
  </p-content-wrapper>

  <script>
    const btn = document.getElementById('btn')
    btn.addEventListener('click', toggle)

    function toggle() {
      const input = document.getElementById('input')
      const { type } = input
      input.type = type === "text" ? "password" : "text"
      btn.setAttribute('variant', type === "text" ? 'secondary' : 'primary')
    }
  </script>
</body>

</html>
```

### Video

https://share.getcloudapp.com/12uzxEWO

### Strategy

- Use Stencil [internal state](https://stenciljs.com/docs/state#when-to-use-state) to trigger re-render if the input type changes
- Observe for the `type` attribute changes and update the state
- Move initialization code related to the input type to a new private method `initInput()`


