### PR TITLE
Feat(components-vue): added createPDS and usePDS for plugin approach

### DIFF
--- a/packages/components-vue/projects/vue-wrapper/README.md
+++ b/packages/components-vue/projects/vue-wrapper/README.md
@@ -58,7 +58,7 @@ You can also use the `PorscheDesignSystemPlugin` to extend your vue setup.
 
 ```vue
 // main.ts
-import { createPDS } from '@porsche-design-system/components-vue';
+import { createPorscheDesignSystem } from '@porsche-design-system/components-vue';
 import { createApp } from 'vue';
 
 const app = createApp(App);

--- a/packages/components-vue/projects/vue-wrapper/README.md
+++ b/packages/components-vue/projects/vue-wrapper/README.md
@@ -74,7 +74,7 @@ The `usePDS` composable provides access to the `PorscheDesignSystemProvider` con
 
 ```vue
 
-const { isPDSLoaded, utilities } = usePDS();
+const { isPorscheDesignSystemLoaded, utilities } = usePorscheDesignSystemPlugin();
 
 ```
 

--- a/packages/components-vue/projects/vue-wrapper/README.md
+++ b/packages/components-vue/projects/vue-wrapper/README.md
@@ -54,7 +54,7 @@ vue setup by the `PorscheDesignSystemProvider` by adding it to your `App.vue` fi
 
 ### Plugin 
 
-You can also use the `PorscheDesignSystemPlugin` to register the components globally.
+You can also use the `PorscheDesignSystemPlugin` to extend your vue setup.
 
 ```vue
 // main.ts

--- a/packages/components-vue/projects/vue-wrapper/README.md
+++ b/packages/components-vue/projects/vue-wrapper/README.md
@@ -52,6 +52,32 @@ vue setup by the `PorscheDesignSystemProvider` by adding it to your `App.vue` fi
 </template>
 ```
 
+### Plugin 
+
+You can also use the `PorscheDesignSystemPlugin` to register the components globally.
+
+```vue
+// main.ts
+import { createPDS } from '@porsche-design-system/components-vue';
+import { createApp } from 'vue';
+
+const app = createApp(App);
+
+app.use(createPDS({ prefix: 'P' }));
+
+app.mount('#app');
+```
+
+### Composable 
+
+The `usePDS` composable provides access to the `PorscheDesignSystemProvider` context.
+
+```vue
+
+const { isPDSLoaded, utilities } = usePDS();
+
+```
+
 
 ## Methodology
 

--- a/packages/components-vue/projects/vue-wrapper/src/plugin.ts
+++ b/packages/components-vue/projects/vue-wrapper/src/plugin.ts
@@ -1,5 +1,5 @@
 // plugin
-import { App, ref, inject } from 'vue';
+import { App, ref, inject, InjectionKey } from 'vue';
 
 import { load, componentsReady } from '@porsche-design-system/components-js';
 import { prefixInjectionKey } from './utils';
@@ -7,14 +7,14 @@ import { prefixInjectionKey } from './utils';
 export type PorscheDesignSystemPluginOptions = {
   prefix?: string;
   extends?: Record<string, unknown>;
-}
+};
 
 export interface PorscheDesignSystemPlugin {
   [key: string]: any;
   install: (app: App, options?: PorscheDesignSystemPluginOptions) => void;
 }
 
-export const porscheDesignSystemSymbol = Symbol();
+export const porscheDesignSystemSymbol: InjectionKey<PorscheDesignSystemPlugin> = Symbol();
 
 export function usePorscheDesignSystemPlugin() {
   const porscheDesignSystem = inject(porscheDesignSystemSymbol);
@@ -30,12 +30,14 @@ export function createPorscheDesignSystem(options = { prefix: '' }) {
     options,
     isPorscheDesignSystemLoaded,
     componentsReady,
-    async install(app) {
-      load();
+    async install(app: App) {
+      load({ prefix: options.prefix });
 
       await componentsReady();
 
-      isPorscheDesignSystemLoaded.value = true;
+      if (!isPorscheDesignSystemLoaded.value) {
+        isPorscheDesignSystemLoaded.value = true;
+      }
       app.provide(prefixInjectionKey, options.prefix);
       app.provide(porscheDesignSystemSymbol, $porscheDesignSystem);
     },

--- a/packages/components-vue/projects/vue-wrapper/src/plugin.ts
+++ b/packages/components-vue/projects/vue-wrapper/src/plugin.ts
@@ -1,0 +1,56 @@
+// plugin
+import { App, ref, inject } from 'vue';
+
+import { load, componentsReady } from '@porsche-design-system/components-js';
+import { prefixInjectionKey } from './utils';
+
+import * as utilities from '@porsche-design-system/utilities';
+
+export interface PDSOptions {
+  prefix?: string;
+  extends?: Record<string, unknown>;
+}
+
+export interface PDSPlugin {
+  [key: string]: any;
+  install: (app: App, options?: PDSOptions) => void;
+}
+
+export const pdsSymbol = Symbol();
+
+export function usePDS() {
+  const pds = inject(pdsSymbol);
+  if (!pds) throw new Error('No PDS provided!!!');
+
+  return pds;
+}
+
+export function createPDS(options = { prefix: '' }) {
+  const isPDSLoaded = ref(false);
+
+  async function initializeComponentAfterPds() {
+    try {
+      await componentsReady();
+      isPDSLoaded.value = true;
+      console.info('[DwaaS] PDS components ready!');
+    } catch (error) {
+      console.error('[DwaaS] - There was an error loading PDS components');
+    }
+  }
+
+  const $pds: PDSPlugin = {
+    options,
+    isPDSLoaded,
+    utilities,
+    componentsReady,
+    install(app) {
+      load();
+
+      initializeComponentAfterPds();
+      app.provide(prefixInjectionKey, options.prefix);
+      app.provide(pdsSymbol, $pds);
+    },
+  };
+
+  return $pds;
+}

--- a/packages/components-vue/projects/vue-wrapper/src/plugin.ts
+++ b/packages/components-vue/projects/vue-wrapper/src/plugin.ts
@@ -31,10 +31,8 @@ export function createPorscheDesignSystem(options = { prefix: '' }) {
     isPorscheDesignSystemLoaded,
     componentsReady,
     async install(app: App) {
-      
       if (!isPorscheDesignSystemLoaded.value) {
         load({ prefix: options.prefix });
-  
         await componentsReady();
         isPorscheDesignSystemLoaded.value = true;
       }

--- a/packages/components-vue/projects/vue-wrapper/src/plugin.ts
+++ b/packages/components-vue/projects/vue-wrapper/src/plugin.ts
@@ -4,53 +4,42 @@ import { App, ref, inject } from 'vue';
 import { load, componentsReady } from '@porsche-design-system/components-js';
 import { prefixInjectionKey } from './utils';
 
-import * as utilities from '@porsche-design-system/utilities';
-
-export interface PDSOptions {
+export type PorscheDesignSystemPluginOptions = {
   prefix?: string;
   extends?: Record<string, unknown>;
 }
 
-export interface PDSPlugin {
+export interface PorscheDesignSystemPlugin {
   [key: string]: any;
-  install: (app: App, options?: PDSOptions) => void;
+  install: (app: App, options?: PorscheDesignSystemPluginOptions) => void;
 }
 
-export const pdsSymbol = Symbol();
+export const porscheDesignSystemSymbol = Symbol();
 
-export function usePDS() {
-  const pds = inject(pdsSymbol);
-  if (!pds) throw new Error('No PDS provided!!!');
+export function usePorscheDesignSystemPlugin() {
+  const porscheDesignSystem = inject(porscheDesignSystemSymbol);
+  if (!porscheDesignSystem) throw new Error('No PorscheDesignSystem provided!!!');
 
-  return pds;
+  return porscheDesignSystem;
 }
 
-export function createPDS(options = { prefix: '' }) {
-  const isPDSLoaded = ref(false);
+export function createPorscheDesignSystem(options = { prefix: '' }) {
+  const isPorscheDesignSystemLoaded = ref(false);
 
-  async function initializeComponentAfterPds() {
-    try {
-      await componentsReady();
-      isPDSLoaded.value = true;
-      console.info('[DwaaS] PDS components ready!');
-    } catch (error) {
-      console.error('[DwaaS] - There was an error loading PDS components');
-    }
-  }
-
-  const $pds: PDSPlugin = {
+  const $porscheDesignSystem: PorscheDesignSystemPlugin = {
     options,
-    isPDSLoaded,
-    utilities,
+    isPorscheDesignSystemLoaded,
     componentsReady,
-    install(app) {
+    async install(app) {
       load();
 
-      initializeComponentAfterPds();
+      await componentsReady();
+
+      isPorscheDesignSystemLoaded.value = true;
       app.provide(prefixInjectionKey, options.prefix);
-      app.provide(pdsSymbol, $pds);
+      app.provide(porscheDesignSystemSymbol, $porscheDesignSystem);
     },
   };
 
-  return $pds;
+  return $porscheDesignSystem;
 }

--- a/packages/components-vue/projects/vue-wrapper/src/plugin.ts
+++ b/packages/components-vue/projects/vue-wrapper/src/plugin.ts
@@ -31,11 +31,11 @@ export function createPorscheDesignSystem(options = { prefix: '' }) {
     isPorscheDesignSystemLoaded,
     componentsReady,
     async install(app: App) {
-      load({ prefix: options.prefix });
-
-      await componentsReady();
-
+      
       if (!isPorscheDesignSystemLoaded.value) {
+        load({ prefix: options.prefix });
+  
+        await componentsReady();
         isPorscheDesignSystemLoaded.value = true;
       }
       app.provide(prefixInjectionKey, options.prefix);

--- a/packages/components-vue/projects/vue-wrapper/src/public-api.ts
+++ b/packages/components-vue/projects/vue-wrapper/src/public-api.ts
@@ -3,4 +3,4 @@ export * from './lib/components';
 export * from './lib/types';
 export { useToastManager } from './utils';
 export { default as PorscheDesignSystemProvider } from './PorscheDesignSystemProvider.vue';
-export { createPDS, usePDS } from './plugin';
+export { createPorscheDesignSystem, usePorscheDesignSystemPlugin } from './plugin';

--- a/packages/components-vue/projects/vue-wrapper/src/public-api.ts
+++ b/packages/components-vue/projects/vue-wrapper/src/public-api.ts
@@ -3,3 +3,4 @@ export * from './lib/components';
 export * from './lib/types';
 export { useToastManager } from './utils';
 export { default as PorscheDesignSystemProvider } from './PorscheDesignSystemProvider.vue';
+export { createPDS, usePDS } from './plugin';

--- a/packages/components-vue/projects/vue-wrapper/tests/unit/specs/plugin.spec.ts
+++ b/packages/components-vue/projects/vue-wrapper/tests/unit/specs/plugin.spec.ts
@@ -1,0 +1,103 @@
+import { createApp, inject } from 'vue';
+import { flushPromises } from '@vue/test-utils';
+// @ts-ignore
+import * as PDS from '@porsche-design-system/components-js';
+jest.mock('@porsche-design-system/components-js', () => ({
+  __esModule: true,
+  ...jest.requireActual('@porsche-design-system/components-js'),
+  load: jest.fn(),
+}));
+
+import { createPorscheDesignSystem } from '../../../src/public-api';
+import { porscheDesignSystemSymbol, usePorscheDesignSystemPlugin } from '../../../src/plugin';
+import { prefixInjectionKey } from '../../../src/utils';
+
+describe('createPorscheDesignSystem', () => {
+  it('should create a porsche design system plugin', () => {
+    const plugin = createPorscheDesignSystem();
+    expect(plugin).toBeDefined();
+  });
+  it('should install the plugin', () => {
+    const plugin = createPorscheDesignSystem();
+    const app = createApp({
+      use: jest.fn(),
+      setup() {},
+    });
+    const spy = jest.spyOn(plugin, 'install');
+    app.use(plugin);
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('should load the porsche design system', async () => {
+    const plugin = createPorscheDesignSystem();
+    const app = createApp({
+      use: jest.fn(),
+      setup() {},
+    });
+    const spy = jest.spyOn(PDS, 'load');
+    app.use(plugin);
+    await flushPromises();
+    expect(spy).toHaveBeenCalledWith({ prefix: '' });
+  });
+
+  it('should load the porsche design system with options', async () => {
+    const plugin = createPorscheDesignSystem({ prefix: 'prefix' });
+    const app = createApp({
+      use: jest.fn(),
+      setup() {},
+    });
+    const spy = jest.spyOn(PDS, 'load');
+    app.use(plugin);
+    await flushPromises();
+    expect(spy).toHaveBeenCalledWith({ prefix: 'prefix' });
+  });
+
+  it('should provide the plugin', async () => {
+    const plugin = createPorscheDesignSystem({ prefix: 'prefix' });
+    const app = createApp({
+      use: jest.fn(),
+      setup() {},
+      provide: jest.fn(),
+    });
+    const spy = jest.spyOn(app, 'provide');
+    app.use(plugin);
+    await flushPromises();
+    expect(spy).toHaveBeenNthCalledWith(1, prefixInjectionKey, 'prefix');
+  });
+
+  it('should isPorscheDesignSystemLoaded be true when installed', async () => {
+    const plugin = createPorscheDesignSystem();
+    const app = createApp({
+      use: jest.fn(),
+      setup() {},
+    });
+    app.use(plugin);
+    await flushPromises();
+    expect(plugin.isPorscheDesignSystemLoaded.value).toBe(true);
+  });
+});
+
+describe('usePorscheDesignSystemPlugin', () => {
+  it('should throw an error when no plugin is provided', () => {
+    expect(() => {
+      usePorscheDesignSystemPlugin();
+    }).toThrowError('No PorscheDesignSystem provided!!!');
+  });
+  it('should return the plugin', async () => {
+    const plugin = createPorscheDesignSystem();
+    const app = createApp({
+      use: jest.fn(),
+      setup() {
+        const porscheDesignSystem = usePorscheDesignSystemPlugin();
+        expect(porscheDesignSystem).toBe(plugin);
+      },
+      provide: {
+        porscheDesignSystemSymbol: plugin,
+      },
+    });
+
+    app.use(plugin);
+
+
+  });
+});


### PR DESCRIPTION
### Pull Request Checklist

<!-- Make sure to read and accept the CLA, before you open the pull request: `CONTRIBUTOR_LICENSE_AGREEMENT` -->
<!-- Tick the checkbox in case you accept it (`[x]`) -->

- [x] I have read and accept the [Contributor License Agreement](https://github.com/porscheofficial/oss-docs/blob/67c5b24838a293ce7a964884e6005eb71f2b8579/CONTRIBUTOR_LICENSE_AGREEMENT.md)

#### References

- Fixes #2232 

#### Scope

Added a Vue Plugin to allow users to install the provider programmatically instead of depending on a template solution only.

### Plugin 

You can also use the `PorscheDesignSystemPlugin` to extend your vue setup.

```vue
// main.ts
import { createPDS } from '@porsche-design-system/components-vue';
import { createApp } from 'vue';

const app = createApp(App);

app.use(createPDS({ prefix: 'P' }));

app.mount('#app');
```

### Composable 

The `usePDS` composable provides access to the `PorscheDesignSystemProvider` context.

```vue

const { isPDSLoaded, utilities } = usePDS();

```
