### PR TITLE
Issue/2349: Adjust getDSRPonyfill partial and SSR Components for changed Declarative Shadow DOM

### DIFF
--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -8,10 +8,6 @@ UX-Pin is not ready for the major babel loader upgrade jet.
 
 - ` babel-loader`
 
-## Partials
-
-Upgrading `@webcomponents/template-shadowroot` causes the dsr-ponyfill tests in playwright to fail
-
 ### Affected dependencies:
 
 - `@webcomponents/template-shadowroot`

--- a/packages/components-js/projects/partials/package.json
+++ b/packages/components-js/projects/partials/package.json
@@ -33,7 +33,7 @@
     "@porsche-design-system/shared": "0.0.0",
     "@porsche-design-system/styles": "0.0.0",
     "@porsche-design-system/utilities-v2": "0.0.0",
-    "@webcomponents/template-shadowroot": "^0.1.0"
+    "@webcomponents/template-shadowroot": "^0.2.1"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^24.0.1",

--- a/packages/components-js/tests/e2e/playwright/specs/dsr-ponyfill.e2e.ts
+++ b/packages/components-js/tests/e2e/playwright/specs/dsr-ponyfill.e2e.ts
@@ -19,7 +19,7 @@ export const setPageWithContent = async (page: Page): Promise<void> => {
   </head>
   <body>
     <p-button>
-      <template shadowrootmode="open">
+      <template shadowroot="open" shadowrootmode="open">
         <style>
           button {
             color: rgb(9, 1, 1);

--- a/packages/components-js/tests/e2e/playwright/specs/dsr-ponyfill.e2e.ts
+++ b/packages/components-js/tests/e2e/playwright/specs/dsr-ponyfill.e2e.ts
@@ -19,7 +19,7 @@ export const setPageWithContent = async (page: Page): Promise<void> => {
   </head>
   <body>
     <p-button>
-      <template shadowroot="open">
+      <template shadowrootmode="open">
         <style>
           button {
             color: rgb(9, 1, 1);

--- a/packages/components-react/projects/react-ssr-wrapper/tests/unit/specs/__snapshots__/react-ssr-wrapper.spec.tsx.snap
+++ b/packages/components-react/projects/react-ssr-wrapper/tests/unit/specs/__snapshots__/react-ssr-wrapper.spec.tsx.snap
@@ -829,7 +829,7 @@ exports[`should render dsr component for PAccordion 1`] = `
   class="ssr"
 >
   <template
-    shadowroot="open"
+    shadowrootmode="open"
   >
     <style>
       :host {
@@ -920,7 +920,7 @@ button::before {
             class="icon ssr"
           >
             <template
-              shadowroot="open"
+              shadowrootmode="open"
             >
               <style>
                 :host {
@@ -977,7 +977,7 @@ exports[`should render dsr component for PBanner 1`] = `
   class="ssr"
 >
   <template
-    shadowroot="open"
+    shadowrootmode="open"
   >
     <style>
       :host {
@@ -1075,7 +1075,7 @@ exports[`should render dsr component for PBanner 1`] = `
       class="ssr"
     >
       <template
-        shadowroot="open"
+        shadowrootmode="open"
       >
         <style>
           :host {
@@ -1131,7 +1131,7 @@ h5,p {
           class="icon ssr"
         >
           <template
-            shadowroot="open"
+            shadowrootmode="open"
           >
             <style>
               :host {
@@ -1185,8 +1185,8 @@ img {
           class="close ssr"
         >
           <template
-            shadowroot="open"
             shadowrootdelegatesfocus="true"
+            shadowrootmode="open"
           >
             <style>
               :host {
@@ -1256,7 +1256,7 @@ img {
                 class="icon ssr"
               >
                 <template
-                  shadowroot="open"
+                  shadowrootmode="open"
                 >
                   <style>
                     :host {
@@ -1311,8 +1311,8 @@ exports[`should render dsr component for PButton 1`] = `
   class="ssr"
 >
   <template
-    shadowroot="open"
     shadowrootdelegatesfocus="true"
+    shadowrootmode="open"
   >
     <style>
       :host {
@@ -1379,7 +1379,7 @@ exports[`should render dsr component for PButtonGroup 1`] = `
   class="ssr"
 >
   <template
-    shadowroot="open"
+    shadowrootmode="open"
   >
     <style>
       :host {
@@ -1417,8 +1417,8 @@ exports[`should render dsr component for PButtonPure 1`] = `
   class="ssr"
 >
   <template
-    shadowroot="open"
     shadowrootdelegatesfocus="true"
+    shadowrootmode="open"
   >
     <style>
       :host {
@@ -1488,7 +1488,7 @@ exports[`should render dsr component for PButtonPure 1`] = `
         class="icon ssr"
       >
         <template
-          shadowroot="open"
+          shadowrootmode="open"
         >
           <style>
             :host {
@@ -1538,8 +1538,8 @@ exports[`should render dsr component for PButtonTile 1`] = `
   class="ssr"
 >
   <template
-    shadowroot="open"
     shadowrootdelegatesfocus="true"
+    shadowrootmode="open"
   >
     <style>
       :host {
@@ -1636,8 +1636,8 @@ p {
           class="link-or-button ssr"
         >
           <template
-            shadowroot="open"
             shadowrootdelegatesfocus="true"
+            shadowrootmode="open"
           >
             <style>
               :host {
@@ -1708,7 +1708,7 @@ exports[`should render dsr component for PCarousel 1`] = `
   class="ssr"
 >
   <template
-    shadowroot="open"
+    shadowrootmode="open"
   >
     <style>
       :host {
@@ -1851,8 +1851,8 @@ h2,::slotted([slot=heading]),p,::slotted([slot=description]) {
           class="btn ssr"
         >
           <template
-            shadowroot="open"
             shadowrootdelegatesfocus="true"
+            shadowrootmode="open"
           >
             <style>
               :host {
@@ -1922,7 +1922,7 @@ h2,::slotted([slot=heading]),p,::slotted([slot=description]) {
                 class="icon ssr"
               >
                 <template
-                  shadowroot="open"
+                  shadowrootmode="open"
                 >
                   <style>
                     :host {
@@ -1968,8 +1968,8 @@ img {
           class="btn ssr"
         >
           <template
-            shadowroot="open"
             shadowrootdelegatesfocus="true"
+            shadowrootmode="open"
           >
             <style>
               :host {
@@ -2039,7 +2039,7 @@ img {
                 class="icon ssr"
               >
                 <template
-                  shadowroot="open"
+                  shadowrootmode="open"
                 >
                   <style>
                     :host {
@@ -2118,7 +2118,7 @@ exports[`should render dsr component for PCheckboxWrapper 1`] = `
   class="ssr"
 >
   <template
-    shadowroot="open"
+    shadowrootmode="open"
   >
     <style>
       :host {
@@ -2208,7 +2208,7 @@ exports[`should render dsr component for PContentWrapper 1`] = `
   class="ssr"
 >
   <template
-    shadowroot="open"
+    shadowrootmode="open"
   >
     <style>
       :host {
@@ -2249,7 +2249,7 @@ exports[`should render dsr component for PDisplay 1`] = `
   class="ssr"
 >
   <template
-    shadowroot="open"
+    shadowrootmode="open"
   >
     <style>
       :host {
@@ -2302,7 +2302,7 @@ exports[`should render dsr component for PDivider 1`] = `
   class="ssr"
 >
   <template
-    shadowroot="open"
+    shadowrootmode="open"
   >
     <style>
       :host {
@@ -2331,7 +2331,7 @@ exports[`should render dsr component for PFieldset 1`] = `
   class="ssr"
 >
   <template
-    shadowroot="open"
+    shadowrootmode="open"
   >
     <style>
       :host {
@@ -2371,7 +2371,7 @@ exports[`should render dsr component for PFieldsetWrapper 1`] = `
   class="ssr"
 >
   <template
-    shadowroot="open"
+    shadowrootmode="open"
   >
     <style>
       :host {
@@ -2411,7 +2411,7 @@ exports[`should render dsr component for PFlex 1`] = `
   class="ssr"
 >
   <template
-    shadowroot="open"
+    shadowrootmode="open"
   >
     <style>
       :host {
@@ -2437,7 +2437,7 @@ exports[`should render dsr component for PFlexItem 1`] = `
   class="ssr"
 >
   <template
-    shadowroot="open"
+    shadowrootmode="open"
   >
     <style>
       :host {
@@ -2463,7 +2463,7 @@ exports[`should render dsr component for PGrid 1`] = `
   class="ssr"
 >
   <template
-    shadowroot="open"
+    shadowrootmode="open"
   >
     <style>
       :host {
@@ -2490,7 +2490,7 @@ exports[`should render dsr component for PGridItem 1`] = `
   class="ssr"
 >
   <template
-    shadowroot="open"
+    shadowrootmode="open"
   >
     <style>
       :host {
@@ -2516,7 +2516,7 @@ exports[`should render dsr component for PHeading 1`] = `
   class="ssr"
 >
   <template
-    shadowroot="open"
+    shadowrootmode="open"
   >
     <style>
       :host {
@@ -2569,7 +2569,7 @@ exports[`should render dsr component for PHeadline 1`] = `
   class="ssr"
 >
   <template
-    shadowroot="open"
+    shadowrootmode="open"
   >
     <style>
       :host {
@@ -2622,7 +2622,7 @@ exports[`should render dsr component for PIcon 1`] = `
   class="ssr"
 >
   <template
-    shadowroot="open"
+    shadowrootmode="open"
   >
     <style>
       :host {
@@ -2664,7 +2664,7 @@ exports[`should render dsr component for PInlineNotification 1`] = `
   class="ssr"
 >
   <template
-    shadowroot="open"
+    shadowrootmode="open"
   >
     <style>
       :host {
@@ -2720,7 +2720,7 @@ h5,p {
       class="icon ssr"
     >
       <template
-        shadowroot="open"
+        shadowrootmode="open"
       >
         <style>
           :host {
@@ -2774,8 +2774,8 @@ img {
       class="close ssr"
     >
       <template
-        shadowroot="open"
         shadowrootdelegatesfocus="true"
+        shadowrootmode="open"
       >
         <style>
           :host {
@@ -2845,7 +2845,7 @@ img {
             class="icon ssr"
           >
             <template
-              shadowroot="open"
+              shadowrootmode="open"
             >
               <style>
                 :host {
@@ -2898,8 +2898,8 @@ exports[`should render dsr component for PLink 1`] = `
   class="ssr"
 >
   <template
-    shadowroot="open"
     shadowrootdelegatesfocus="true"
+    shadowrootmode="open"
   >
     <style>
       :host {
@@ -2982,8 +2982,8 @@ exports[`should render dsr component for PLinkPure 1`] = `
   class="ssr"
 >
   <template
-    shadowroot="open"
     shadowrootdelegatesfocus="true"
+    shadowrootmode="open"
   >
     <style>
       :host {
@@ -3067,7 +3067,7 @@ exports[`should render dsr component for PLinkPure 1`] = `
         class="icon ssr"
       >
         <template
-          shadowroot="open"
+          shadowrootmode="open"
         >
           <style>
             :host {
@@ -3117,8 +3117,8 @@ exports[`should render dsr component for PLinkSocial 1`] = `
   class="ssr"
 >
   <template
-    shadowroot="open"
     shadowrootdelegatesfocus="true"
+    shadowrootmode="open"
   >
     <style>
       :host {
@@ -3194,7 +3194,7 @@ exports[`should render dsr component for PLinkSocial 1`] = `
         class="icon ssr"
       >
         <template
-          shadowroot="open"
+          shadowrootmode="open"
         >
           <style>
             :host {
@@ -3244,8 +3244,8 @@ exports[`should render dsr component for PLinkTile 1`] = `
   class="ssr"
 >
   <template
-    shadowroot="open"
     shadowrootdelegatesfocus="true"
+    shadowrootmode="open"
   >
     <style>
       :host {
@@ -3356,8 +3356,8 @@ p {
           class="link-or-button ssr"
         >
           <template
-            shadowroot="open"
             shadowrootdelegatesfocus="true"
+            shadowrootmode="open"
           >
             <style>
               :host {
@@ -3444,8 +3444,8 @@ exports[`should render dsr component for PMarque 1`] = `
   class="ssr"
 >
   <template
-    shadowroot="open"
     shadowrootdelegatesfocus="true"
+    shadowrootmode="open"
   >
     <style>
       :host {
@@ -3526,7 +3526,7 @@ exports[`should render dsr component for PModal 1`] = `
   class="ssr"
 >
   <template
-    shadowroot="open"
+    shadowrootmode="open"
   >
     <style>
       :host {
@@ -3621,8 +3621,8 @@ h2 {
         class="dismiss ssr"
       >
         <template
-          shadowroot="open"
           shadowrootdelegatesfocus="true"
+          shadowrootmode="open"
         >
           <style>
             :host {
@@ -3692,7 +3692,7 @@ h2 {
               class="icon ssr"
             >
               <template
-                shadowroot="open"
+                shadowrootmode="open"
               >
                 <style>
                   :host {
@@ -3747,7 +3747,7 @@ exports[`should render dsr component for PModelSignature 1`] = `
   class="ssr"
 >
   <template
-    shadowroot="open"
+    shadowrootmode="open"
   >
     <style>
       :host {
@@ -3776,8 +3776,8 @@ exports[`should render dsr component for PPagination 1`] = `
   class="ssr"
 >
   <template
-    shadowroot="open"
     shadowrootdelegatesfocus="true"
+    shadowrootmode="open"
   >
     <style>
       :host {
@@ -3873,7 +3873,7 @@ span[aria-disabled] {
               class="ssr"
             >
               <template
-                shadowroot="open"
+                shadowrootmode="open"
               >
                 <style>
                   :host {
@@ -3931,7 +3931,7 @@ img {
               class="ssr"
             >
               <template
-                shadowroot="open"
+                shadowrootmode="open"
               >
                 <style>
                   :host {
@@ -3979,8 +3979,8 @@ exports[`should render dsr component for PPopover 1`] = `
   class="ssr"
 >
   <template
-    shadowroot="open"
     shadowrootdelegatesfocus="true"
+    shadowrootmode="open"
   >
     <style>
       :host {
@@ -4105,7 +4105,7 @@ button::before {
         class="icon ssr"
       >
         <template
-          shadowroot="open"
+          shadowrootmode="open"
         >
           <style>
             :host {
@@ -4156,7 +4156,7 @@ exports[`should render dsr component for PRadioButtonWrapper 1`] = `
   class="ssr"
 >
   <template
-    shadowroot="open"
+    shadowrootmode="open"
   >
     <style>
       :host {
@@ -4243,7 +4243,7 @@ exports[`should render dsr component for PScroller 1`] = `
   class="ssr"
 >
   <template
-    shadowroot="open"
+    shadowrootmode="open"
   >
     <style>
       :host {
@@ -4385,7 +4385,7 @@ button {
             class="icon ssr"
           >
             <template
-              shadowroot="open"
+              shadowrootmode="open"
             >
               <style>
                 :host {
@@ -4435,7 +4435,7 @@ img {
             class="icon ssr"
           >
             <template
-              shadowroot="open"
+              shadowrootmode="open"
             >
               <style>
                 :host {
@@ -4484,7 +4484,7 @@ exports[`should render dsr component for PSegmentedControl 1`] = `
   role="group"
 >
   <template
-    shadowroot="open"
+    shadowrootmode="open"
   >
     <style>
       :host {
@@ -4508,8 +4508,8 @@ exports[`should render dsr component for PSegmentedControlItem 1`] = `
   class="ssr"
 >
   <template
-    shadowroot="open"
     shadowrootdelegatesfocus="true"
+    shadowrootmode="open"
   >
     <style>
       :host {
@@ -4575,7 +4575,7 @@ exports[`should render dsr component for PSelectWrapper 1`] = `
   class="ssr"
 >
   <template
-    shadowroot="open"
+    shadowrootmode="open"
   >
     <style>
       :host {
@@ -4679,7 +4679,7 @@ exports[`should render dsr component for PSelectWrapper 1`] = `
           class="icon ssr"
         >
           <template
-            shadowroot="open"
+            shadowrootmode="open"
           >
             <style>
               :host {
@@ -4727,7 +4727,7 @@ exports[`should render dsr component for PSpinner 1`] = `
   class="ssr"
 >
   <template
-    shadowroot="open"
+    shadowrootmode="open"
   >
     <style>
       :host {
@@ -4833,7 +4833,7 @@ exports[`should render dsr component for PStepperHorizontal 1`] = `
   role="list"
 >
   <template
-    shadowroot="open"
+    shadowrootmode="open"
   >
     <style>
       :host {
@@ -4853,7 +4853,7 @@ exports[`should render dsr component for PStepperHorizontal 1`] = `
       class="scroller ssr"
     >
       <template
-        shadowroot="open"
+        shadowrootmode="open"
       >
         <style>
           :host {
@@ -4995,7 +4995,7 @@ button {
                 class="icon ssr"
               >
                 <template
-                  shadowroot="open"
+                  shadowrootmode="open"
                 >
                   <style>
                     :host {
@@ -5045,7 +5045,7 @@ img {
                 class="icon ssr"
               >
                 <template
-                  shadowroot="open"
+                  shadowrootmode="open"
                 >
                   <style>
                     :host {
@@ -5097,8 +5097,8 @@ exports[`should render dsr component for PStepperHorizontalItem 1`] = `
   role="listitem"
 >
   <template
-    shadowroot="open"
     shadowrootdelegatesfocus="true"
+    shadowrootmode="open"
   >
     <style>
       :host {
@@ -5187,8 +5187,8 @@ exports[`should render dsr component for PSwitch 1`] = `
   class="ssr"
 >
   <template
-    shadowroot="open"
     shadowrootdelegatesfocus="true"
+    shadowrootmode="open"
   >
     <style>
       :host {
@@ -5287,7 +5287,7 @@ exports[`should render dsr component for PTable 1`] = `
   class="ssr"
 >
   <template
-    shadowroot="open"
+    shadowrootmode="open"
   >
     <style>
       :host {
@@ -5388,7 +5388,7 @@ exports[`should render dsr component for PTableBody 1`] = `
   role="rowgroup"
 >
   <template
-    shadowroot="open"
+    shadowrootmode="open"
   >
     <style>
       :host {
@@ -5410,7 +5410,7 @@ exports[`should render dsr component for PTableCell 1`] = `
   role="cell"
 >
   <template
-    shadowroot="open"
+    shadowrootmode="open"
   >
     <style>
       :host {
@@ -5437,7 +5437,7 @@ exports[`should render dsr component for PTableHead 1`] = `
   role="rowgroup"
 >
   <template
-    shadowroot="open"
+    shadowrootmode="open"
   >
     <style>
       :host {
@@ -5460,7 +5460,7 @@ exports[`should render dsr component for PTableHeadCell 1`] = `
   scope="col"
 >
   <template
-    shadowroot="open"
+    shadowrootmode="open"
   >
     <style>
       :host {
@@ -5489,7 +5489,7 @@ exports[`should render dsr component for PTableHeadRow 1`] = `
   role="row"
 >
   <template
-    shadowroot="open"
+    shadowrootmode="open"
   >
     <style>
       :host {
@@ -5511,7 +5511,7 @@ exports[`should render dsr component for PTableRow 1`] = `
   role="row"
 >
   <template
-    shadowroot="open"
+    shadowrootmode="open"
   >
     <style>
       :host {
@@ -5533,7 +5533,7 @@ exports[`should render dsr component for PTabs 1`] = `
   class="ssr"
 >
   <template
-    shadowroot="open"
+    shadowrootmode="open"
   >
     <style>
       :host {
@@ -5550,7 +5550,7 @@ exports[`should render dsr component for PTabs 1`] = `
       class="root ssr"
     >
       <template
-        shadowroot="open"
+        shadowrootmode="open"
       >
         <style>
           :host {
@@ -5627,7 +5627,7 @@ exports[`should render dsr component for PTabs 1`] = `
           role="tablist"
         >
           <template
-            shadowroot="open"
+            shadowrootmode="open"
           >
             <style>
               :host {
@@ -5769,7 +5769,7 @@ button {
                     class="icon ssr"
                   >
                     <template
-                      shadowroot="open"
+                      shadowrootmode="open"
                     >
                       <style>
                         :host {
@@ -5819,7 +5819,7 @@ img {
                     class="icon ssr"
                   >
                     <template
-                      shadowroot="open"
+                      shadowrootmode="open"
                     >
                       <style>
                         :host {
@@ -5884,7 +5884,7 @@ exports[`should render dsr component for PTabsBar 1`] = `
   class="ssr"
 >
   <template
-    shadowroot="open"
+    shadowrootmode="open"
   >
     <style>
       :host {
@@ -5961,7 +5961,7 @@ exports[`should render dsr component for PTabsBar 1`] = `
       role="tablist"
     >
       <template
-        shadowroot="open"
+        shadowrootmode="open"
       >
         <style>
           :host {
@@ -6103,7 +6103,7 @@ button {
                 class="icon ssr"
               >
                 <template
-                  shadowroot="open"
+                  shadowrootmode="open"
                 >
                   <style>
                     :host {
@@ -6153,7 +6153,7 @@ img {
                 class="icon ssr"
               >
                 <template
-                  shadowroot="open"
+                  shadowrootmode="open"
                 >
                   <style>
                     :host {
@@ -6207,7 +6207,7 @@ exports[`should render dsr component for PTabsItem 1`] = `
   class="ssr"
 >
   <template
-    shadowroot="open"
+    shadowrootmode="open"
   >
     <style>
       :host {
@@ -6239,7 +6239,7 @@ exports[`should render dsr component for PTag 1`] = `
   class="ssr"
 >
   <template
-    shadowroot="open"
+    shadowrootmode="open"
   >
     <style>
       :host {
@@ -6301,8 +6301,8 @@ exports[`should render dsr component for PTagDismissible 1`] = `
   class="ssr"
 >
   <template
-    shadowroot="open"
     shadowrootdelegatesfocus="true"
+    shadowrootmode="open"
   >
     <style>
       :host {
@@ -6366,7 +6366,7 @@ button {
         class="icon ssr"
       >
         <template
-          shadowroot="open"
+          shadowrootmode="open"
         >
           <style>
             :host {
@@ -6412,7 +6412,7 @@ exports[`should render dsr component for PText 1`] = `
   class="ssr"
 >
   <template
-    shadowroot="open"
+    shadowrootmode="open"
   >
     <style>
       :host {
@@ -6468,7 +6468,7 @@ exports[`should render dsr component for PTextFieldWrapper 1`] = `
   class="ssr"
 >
   <template
-    shadowroot="open"
+    shadowrootmode="open"
   >
     <style>
       :host {
@@ -6586,7 +6586,7 @@ exports[`should render dsr component for PTextList 1`] = `
   class="ssr"
 >
   <template
-    shadowroot="open"
+    shadowrootmode="open"
   >
     <style>
       :host {
@@ -6627,7 +6627,7 @@ exports[`should render dsr component for PTextListItem 1`] = `
   role="listitem"
 >
   <template
-    shadowroot="open"
+    shadowrootmode="open"
   >
     <style>
       :host {
@@ -6656,7 +6656,7 @@ exports[`should render dsr component for PTextareaWrapper 1`] = `
   class="ssr"
 >
   <template
-    shadowroot="open"
+    shadowrootmode="open"
   >
     <style>
       :host {
@@ -6752,7 +6752,7 @@ exports[`should render dsr component for PToast 1`] = `
   class="ssr"
 >
   <template
-    shadowroot="open"
+    shadowrootmode="open"
   >
     <style>
       :host {

--- a/packages/components-react/projects/react-ssr-wrapper/tests/unit/specs/__snapshots__/react-ssr-wrapper.spec.tsx.snap
+++ b/packages/components-react/projects/react-ssr-wrapper/tests/unit/specs/__snapshots__/react-ssr-wrapper.spec.tsx.snap
@@ -829,6 +829,7 @@ exports[`should render dsr component for PAccordion 1`] = `
   class="ssr"
 >
   <template
+    shadowroot="open"
     shadowrootmode="open"
   >
     <style>
@@ -920,6 +921,7 @@ button::before {
             class="icon ssr"
           >
             <template
+              shadowroot="open"
               shadowrootmode="open"
             >
               <style>
@@ -977,6 +979,7 @@ exports[`should render dsr component for PBanner 1`] = `
   class="ssr"
 >
   <template
+    shadowroot="open"
     shadowrootmode="open"
   >
     <style>
@@ -1075,6 +1078,7 @@ exports[`should render dsr component for PBanner 1`] = `
       class="ssr"
     >
       <template
+        shadowroot="open"
         shadowrootmode="open"
       >
         <style>
@@ -1131,6 +1135,7 @@ h5,p {
           class="icon ssr"
         >
           <template
+            shadowroot="open"
             shadowrootmode="open"
           >
             <style>
@@ -1185,6 +1190,7 @@ img {
           class="close ssr"
         >
           <template
+            shadowroot="open"
             shadowrootdelegatesfocus="true"
             shadowrootmode="open"
           >
@@ -1256,6 +1262,7 @@ img {
                 class="icon ssr"
               >
                 <template
+                  shadowroot="open"
                   shadowrootmode="open"
                 >
                   <style>
@@ -1311,6 +1318,7 @@ exports[`should render dsr component for PButton 1`] = `
   class="ssr"
 >
   <template
+    shadowroot="open"
     shadowrootdelegatesfocus="true"
     shadowrootmode="open"
   >
@@ -1379,6 +1387,7 @@ exports[`should render dsr component for PButtonGroup 1`] = `
   class="ssr"
 >
   <template
+    shadowroot="open"
     shadowrootmode="open"
   >
     <style>
@@ -1417,6 +1426,7 @@ exports[`should render dsr component for PButtonPure 1`] = `
   class="ssr"
 >
   <template
+    shadowroot="open"
     shadowrootdelegatesfocus="true"
     shadowrootmode="open"
   >
@@ -1488,6 +1498,7 @@ exports[`should render dsr component for PButtonPure 1`] = `
         class="icon ssr"
       >
         <template
+          shadowroot="open"
           shadowrootmode="open"
         >
           <style>
@@ -1538,6 +1549,7 @@ exports[`should render dsr component for PButtonTile 1`] = `
   class="ssr"
 >
   <template
+    shadowroot="open"
     shadowrootdelegatesfocus="true"
     shadowrootmode="open"
   >
@@ -1636,6 +1648,7 @@ p {
           class="link-or-button ssr"
         >
           <template
+            shadowroot="open"
             shadowrootdelegatesfocus="true"
             shadowrootmode="open"
           >
@@ -1708,6 +1721,7 @@ exports[`should render dsr component for PCarousel 1`] = `
   class="ssr"
 >
   <template
+    shadowroot="open"
     shadowrootmode="open"
   >
     <style>
@@ -1851,6 +1865,7 @@ h2,::slotted([slot=heading]),p,::slotted([slot=description]) {
           class="btn ssr"
         >
           <template
+            shadowroot="open"
             shadowrootdelegatesfocus="true"
             shadowrootmode="open"
           >
@@ -1922,6 +1937,7 @@ h2,::slotted([slot=heading]),p,::slotted([slot=description]) {
                 class="icon ssr"
               >
                 <template
+                  shadowroot="open"
                   shadowrootmode="open"
                 >
                   <style>
@@ -1968,6 +1984,7 @@ img {
           class="btn ssr"
         >
           <template
+            shadowroot="open"
             shadowrootdelegatesfocus="true"
             shadowrootmode="open"
           >
@@ -2039,6 +2056,7 @@ img {
                 class="icon ssr"
               >
                 <template
+                  shadowroot="open"
                   shadowrootmode="open"
                 >
                   <style>
@@ -2118,6 +2136,7 @@ exports[`should render dsr component for PCheckboxWrapper 1`] = `
   class="ssr"
 >
   <template
+    shadowroot="open"
     shadowrootmode="open"
   >
     <style>
@@ -2208,6 +2227,7 @@ exports[`should render dsr component for PContentWrapper 1`] = `
   class="ssr"
 >
   <template
+    shadowroot="open"
     shadowrootmode="open"
   >
     <style>
@@ -2249,6 +2269,7 @@ exports[`should render dsr component for PDisplay 1`] = `
   class="ssr"
 >
   <template
+    shadowroot="open"
     shadowrootmode="open"
   >
     <style>
@@ -2302,6 +2323,7 @@ exports[`should render dsr component for PDivider 1`] = `
   class="ssr"
 >
   <template
+    shadowroot="open"
     shadowrootmode="open"
   >
     <style>
@@ -2331,6 +2353,7 @@ exports[`should render dsr component for PFieldset 1`] = `
   class="ssr"
 >
   <template
+    shadowroot="open"
     shadowrootmode="open"
   >
     <style>
@@ -2371,6 +2394,7 @@ exports[`should render dsr component for PFieldsetWrapper 1`] = `
   class="ssr"
 >
   <template
+    shadowroot="open"
     shadowrootmode="open"
   >
     <style>
@@ -2411,6 +2435,7 @@ exports[`should render dsr component for PFlex 1`] = `
   class="ssr"
 >
   <template
+    shadowroot="open"
     shadowrootmode="open"
   >
     <style>
@@ -2437,6 +2462,7 @@ exports[`should render dsr component for PFlexItem 1`] = `
   class="ssr"
 >
   <template
+    shadowroot="open"
     shadowrootmode="open"
   >
     <style>
@@ -2463,6 +2489,7 @@ exports[`should render dsr component for PGrid 1`] = `
   class="ssr"
 >
   <template
+    shadowroot="open"
     shadowrootmode="open"
   >
     <style>
@@ -2490,6 +2517,7 @@ exports[`should render dsr component for PGridItem 1`] = `
   class="ssr"
 >
   <template
+    shadowroot="open"
     shadowrootmode="open"
   >
     <style>
@@ -2516,6 +2544,7 @@ exports[`should render dsr component for PHeading 1`] = `
   class="ssr"
 >
   <template
+    shadowroot="open"
     shadowrootmode="open"
   >
     <style>
@@ -2569,6 +2598,7 @@ exports[`should render dsr component for PHeadline 1`] = `
   class="ssr"
 >
   <template
+    shadowroot="open"
     shadowrootmode="open"
   >
     <style>
@@ -2622,6 +2652,7 @@ exports[`should render dsr component for PIcon 1`] = `
   class="ssr"
 >
   <template
+    shadowroot="open"
     shadowrootmode="open"
   >
     <style>
@@ -2664,6 +2695,7 @@ exports[`should render dsr component for PInlineNotification 1`] = `
   class="ssr"
 >
   <template
+    shadowroot="open"
     shadowrootmode="open"
   >
     <style>
@@ -2720,6 +2752,7 @@ h5,p {
       class="icon ssr"
     >
       <template
+        shadowroot="open"
         shadowrootmode="open"
       >
         <style>
@@ -2774,6 +2807,7 @@ img {
       class="close ssr"
     >
       <template
+        shadowroot="open"
         shadowrootdelegatesfocus="true"
         shadowrootmode="open"
       >
@@ -2845,6 +2879,7 @@ img {
             class="icon ssr"
           >
             <template
+              shadowroot="open"
               shadowrootmode="open"
             >
               <style>
@@ -2898,6 +2933,7 @@ exports[`should render dsr component for PLink 1`] = `
   class="ssr"
 >
   <template
+    shadowroot="open"
     shadowrootdelegatesfocus="true"
     shadowrootmode="open"
   >
@@ -2982,6 +3018,7 @@ exports[`should render dsr component for PLinkPure 1`] = `
   class="ssr"
 >
   <template
+    shadowroot="open"
     shadowrootdelegatesfocus="true"
     shadowrootmode="open"
   >
@@ -3067,6 +3104,7 @@ exports[`should render dsr component for PLinkPure 1`] = `
         class="icon ssr"
       >
         <template
+          shadowroot="open"
           shadowrootmode="open"
         >
           <style>
@@ -3117,6 +3155,7 @@ exports[`should render dsr component for PLinkSocial 1`] = `
   class="ssr"
 >
   <template
+    shadowroot="open"
     shadowrootdelegatesfocus="true"
     shadowrootmode="open"
   >
@@ -3194,6 +3233,7 @@ exports[`should render dsr component for PLinkSocial 1`] = `
         class="icon ssr"
       >
         <template
+          shadowroot="open"
           shadowrootmode="open"
         >
           <style>
@@ -3244,6 +3284,7 @@ exports[`should render dsr component for PLinkTile 1`] = `
   class="ssr"
 >
   <template
+    shadowroot="open"
     shadowrootdelegatesfocus="true"
     shadowrootmode="open"
   >
@@ -3356,6 +3397,7 @@ p {
           class="link-or-button ssr"
         >
           <template
+            shadowroot="open"
             shadowrootdelegatesfocus="true"
             shadowrootmode="open"
           >
@@ -3444,6 +3486,7 @@ exports[`should render dsr component for PMarque 1`] = `
   class="ssr"
 >
   <template
+    shadowroot="open"
     shadowrootdelegatesfocus="true"
     shadowrootmode="open"
   >
@@ -3526,6 +3569,7 @@ exports[`should render dsr component for PModal 1`] = `
   class="ssr"
 >
   <template
+    shadowroot="open"
     shadowrootmode="open"
   >
     <style>
@@ -3621,6 +3665,7 @@ h2 {
         class="dismiss ssr"
       >
         <template
+          shadowroot="open"
           shadowrootdelegatesfocus="true"
           shadowrootmode="open"
         >
@@ -3692,6 +3737,7 @@ h2 {
               class="icon ssr"
             >
               <template
+                shadowroot="open"
                 shadowrootmode="open"
               >
                 <style>
@@ -3747,6 +3793,7 @@ exports[`should render dsr component for PModelSignature 1`] = `
   class="ssr"
 >
   <template
+    shadowroot="open"
     shadowrootmode="open"
   >
     <style>
@@ -3776,6 +3823,7 @@ exports[`should render dsr component for PPagination 1`] = `
   class="ssr"
 >
   <template
+    shadowroot="open"
     shadowrootdelegatesfocus="true"
     shadowrootmode="open"
   >
@@ -3873,6 +3921,7 @@ span[aria-disabled] {
               class="ssr"
             >
               <template
+                shadowroot="open"
                 shadowrootmode="open"
               >
                 <style>
@@ -3931,6 +3980,7 @@ img {
               class="ssr"
             >
               <template
+                shadowroot="open"
                 shadowrootmode="open"
               >
                 <style>
@@ -3979,6 +4029,7 @@ exports[`should render dsr component for PPopover 1`] = `
   class="ssr"
 >
   <template
+    shadowroot="open"
     shadowrootdelegatesfocus="true"
     shadowrootmode="open"
   >
@@ -4105,6 +4156,7 @@ button::before {
         class="icon ssr"
       >
         <template
+          shadowroot="open"
           shadowrootmode="open"
         >
           <style>
@@ -4156,6 +4208,7 @@ exports[`should render dsr component for PRadioButtonWrapper 1`] = `
   class="ssr"
 >
   <template
+    shadowroot="open"
     shadowrootmode="open"
   >
     <style>
@@ -4243,6 +4296,7 @@ exports[`should render dsr component for PScroller 1`] = `
   class="ssr"
 >
   <template
+    shadowroot="open"
     shadowrootmode="open"
   >
     <style>
@@ -4385,6 +4439,7 @@ button {
             class="icon ssr"
           >
             <template
+              shadowroot="open"
               shadowrootmode="open"
             >
               <style>
@@ -4435,6 +4490,7 @@ img {
             class="icon ssr"
           >
             <template
+              shadowroot="open"
               shadowrootmode="open"
             >
               <style>
@@ -4484,6 +4540,7 @@ exports[`should render dsr component for PSegmentedControl 1`] = `
   role="group"
 >
   <template
+    shadowroot="open"
     shadowrootmode="open"
   >
     <style>
@@ -4508,6 +4565,7 @@ exports[`should render dsr component for PSegmentedControlItem 1`] = `
   class="ssr"
 >
   <template
+    shadowroot="open"
     shadowrootdelegatesfocus="true"
     shadowrootmode="open"
   >
@@ -4575,6 +4633,7 @@ exports[`should render dsr component for PSelectWrapper 1`] = `
   class="ssr"
 >
   <template
+    shadowroot="open"
     shadowrootmode="open"
   >
     <style>
@@ -4679,6 +4738,7 @@ exports[`should render dsr component for PSelectWrapper 1`] = `
           class="icon ssr"
         >
           <template
+            shadowroot="open"
             shadowrootmode="open"
           >
             <style>
@@ -4727,6 +4787,7 @@ exports[`should render dsr component for PSpinner 1`] = `
   class="ssr"
 >
   <template
+    shadowroot="open"
     shadowrootmode="open"
   >
     <style>
@@ -4833,6 +4894,7 @@ exports[`should render dsr component for PStepperHorizontal 1`] = `
   role="list"
 >
   <template
+    shadowroot="open"
     shadowrootmode="open"
   >
     <style>
@@ -4853,6 +4915,7 @@ exports[`should render dsr component for PStepperHorizontal 1`] = `
       class="scroller ssr"
     >
       <template
+        shadowroot="open"
         shadowrootmode="open"
       >
         <style>
@@ -4995,6 +5058,7 @@ button {
                 class="icon ssr"
               >
                 <template
+                  shadowroot="open"
                   shadowrootmode="open"
                 >
                   <style>
@@ -5045,6 +5109,7 @@ img {
                 class="icon ssr"
               >
                 <template
+                  shadowroot="open"
                   shadowrootmode="open"
                 >
                   <style>
@@ -5097,6 +5162,7 @@ exports[`should render dsr component for PStepperHorizontalItem 1`] = `
   role="listitem"
 >
   <template
+    shadowroot="open"
     shadowrootdelegatesfocus="true"
     shadowrootmode="open"
   >
@@ -5187,6 +5253,7 @@ exports[`should render dsr component for PSwitch 1`] = `
   class="ssr"
 >
   <template
+    shadowroot="open"
     shadowrootdelegatesfocus="true"
     shadowrootmode="open"
   >
@@ -5287,6 +5354,7 @@ exports[`should render dsr component for PTable 1`] = `
   class="ssr"
 >
   <template
+    shadowroot="open"
     shadowrootmode="open"
   >
     <style>
@@ -5388,6 +5456,7 @@ exports[`should render dsr component for PTableBody 1`] = `
   role="rowgroup"
 >
   <template
+    shadowroot="open"
     shadowrootmode="open"
   >
     <style>
@@ -5410,6 +5479,7 @@ exports[`should render dsr component for PTableCell 1`] = `
   role="cell"
 >
   <template
+    shadowroot="open"
     shadowrootmode="open"
   >
     <style>
@@ -5437,6 +5507,7 @@ exports[`should render dsr component for PTableHead 1`] = `
   role="rowgroup"
 >
   <template
+    shadowroot="open"
     shadowrootmode="open"
   >
     <style>
@@ -5460,6 +5531,7 @@ exports[`should render dsr component for PTableHeadCell 1`] = `
   scope="col"
 >
   <template
+    shadowroot="open"
     shadowrootmode="open"
   >
     <style>
@@ -5489,6 +5561,7 @@ exports[`should render dsr component for PTableHeadRow 1`] = `
   role="row"
 >
   <template
+    shadowroot="open"
     shadowrootmode="open"
   >
     <style>
@@ -5511,6 +5584,7 @@ exports[`should render dsr component for PTableRow 1`] = `
   role="row"
 >
   <template
+    shadowroot="open"
     shadowrootmode="open"
   >
     <style>
@@ -5533,6 +5607,7 @@ exports[`should render dsr component for PTabs 1`] = `
   class="ssr"
 >
   <template
+    shadowroot="open"
     shadowrootmode="open"
   >
     <style>
@@ -5550,6 +5625,7 @@ exports[`should render dsr component for PTabs 1`] = `
       class="root ssr"
     >
       <template
+        shadowroot="open"
         shadowrootmode="open"
       >
         <style>
@@ -5627,6 +5703,7 @@ exports[`should render dsr component for PTabs 1`] = `
           role="tablist"
         >
           <template
+            shadowroot="open"
             shadowrootmode="open"
           >
             <style>
@@ -5769,6 +5846,7 @@ button {
                     class="icon ssr"
                   >
                     <template
+                      shadowroot="open"
                       shadowrootmode="open"
                     >
                       <style>
@@ -5819,6 +5897,7 @@ img {
                     class="icon ssr"
                   >
                     <template
+                      shadowroot="open"
                       shadowrootmode="open"
                     >
                       <style>
@@ -5884,6 +5963,7 @@ exports[`should render dsr component for PTabsBar 1`] = `
   class="ssr"
 >
   <template
+    shadowroot="open"
     shadowrootmode="open"
   >
     <style>
@@ -5961,6 +6041,7 @@ exports[`should render dsr component for PTabsBar 1`] = `
       role="tablist"
     >
       <template
+        shadowroot="open"
         shadowrootmode="open"
       >
         <style>
@@ -6103,6 +6184,7 @@ button {
                 class="icon ssr"
               >
                 <template
+                  shadowroot="open"
                   shadowrootmode="open"
                 >
                   <style>
@@ -6153,6 +6235,7 @@ img {
                 class="icon ssr"
               >
                 <template
+                  shadowroot="open"
                   shadowrootmode="open"
                 >
                   <style>
@@ -6207,6 +6290,7 @@ exports[`should render dsr component for PTabsItem 1`] = `
   class="ssr"
 >
   <template
+    shadowroot="open"
     shadowrootmode="open"
   >
     <style>
@@ -6239,6 +6323,7 @@ exports[`should render dsr component for PTag 1`] = `
   class="ssr"
 >
   <template
+    shadowroot="open"
     shadowrootmode="open"
   >
     <style>
@@ -6301,6 +6386,7 @@ exports[`should render dsr component for PTagDismissible 1`] = `
   class="ssr"
 >
   <template
+    shadowroot="open"
     shadowrootdelegatesfocus="true"
     shadowrootmode="open"
   >
@@ -6366,6 +6452,7 @@ button {
         class="icon ssr"
       >
         <template
+          shadowroot="open"
           shadowrootmode="open"
         >
           <style>
@@ -6412,6 +6499,7 @@ exports[`should render dsr component for PText 1`] = `
   class="ssr"
 >
   <template
+    shadowroot="open"
     shadowrootmode="open"
   >
     <style>
@@ -6468,6 +6556,7 @@ exports[`should render dsr component for PTextFieldWrapper 1`] = `
   class="ssr"
 >
   <template
+    shadowroot="open"
     shadowrootmode="open"
   >
     <style>
@@ -6586,6 +6675,7 @@ exports[`should render dsr component for PTextList 1`] = `
   class="ssr"
 >
   <template
+    shadowroot="open"
     shadowrootmode="open"
   >
     <style>
@@ -6627,6 +6717,7 @@ exports[`should render dsr component for PTextListItem 1`] = `
   role="listitem"
 >
   <template
+    shadowroot="open"
     shadowrootmode="open"
   >
     <style>
@@ -6656,6 +6747,7 @@ exports[`should render dsr component for PTextareaWrapper 1`] = `
   class="ssr"
 >
   <template
+    shadowroot="open"
     shadowrootmode="open"
   >
     <style>
@@ -6752,6 +6844,7 @@ exports[`should render dsr component for PToast 1`] = `
   class="ssr"
 >
   <template
+    shadowroot="open"
     shadowrootmode="open"
   >
     <style>

--- a/packages/components-react/projects/react-ssr-wrapper/tests/unit/specs/react-ssr-wrapper-bundling.spec.ts
+++ b/packages/components-react/projects/react-ssr-wrapper/tests/unit/specs/react-ssr-wrapper-bundling.spec.ts
@@ -19,7 +19,7 @@ describe('nextjs', () => {
       (_, jsFilePath) => {
         const fileContent = fs.readFileSync(jsFilePath, 'utf8');
 
-        expect(fileContent).not.toContain('shadowroot');
+        expect(fileContent).not.toContain('shadowrootmode');
         expect(fileContent).not.toContain('shadowrootdelegatesfocus');
         expect(fileContent).not.toContain('process.browser');
         expect(fileContent).not.toContain('"ssr"'); // added className from server build
@@ -60,7 +60,7 @@ describe('remix', () => {
       (_, jsFilePath) => {
         const fileContent = fs.readFileSync(jsFilePath, 'utf8');
 
-        expect(fileContent).not.toContain('shadowroot');
+        expect(fileContent).not.toContain('shadowrootmode');
         expect(fileContent).not.toContain('shadowrootdelegatesfocus');
         expect(fileContent).not.toContain('process.browser');
         expect(fileContent).not.toContain('"ssr"'); // added className from server build

--- a/packages/components/scripts/generateDSRComponents.ts
+++ b/packages/components/scripts/generateDSRComponents.ts
@@ -118,7 +118,7 @@ import { get${componentName}Css } from '${stylesBundleImportPath}';
     return (
       <>
         {/* @ts-ignore */}
-        <template shadowroot="open"${delegatesFocusProp}>
+        <template shadowrootmode="open"${delegatesFocusProp}>
           <style dangerouslySetInnerHTML={{ __html: style }} />
           ${g1.trim().replace(/\n/g, '$&    ')}
         </template>${children}

--- a/packages/components/scripts/generateDSRComponents.ts
+++ b/packages/components/scripts/generateDSRComponents.ts
@@ -118,7 +118,7 @@ import { get${componentName}Css } from '${stylesBundleImportPath}';
     return (
       <>
         {/* @ts-ignore */}
-        <template shadowrootmode="open"${delegatesFocusProp}>
+        <template shadowroot="open" shadowrootmode="open"${delegatesFocusProp}>
           <style dangerouslySetInnerHTML={{ __html: style }} />
           ${g1.trim().replace(/\n/g, '$&    ')}
         </template>${children}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3153,14 +3153,6 @@
   resolved "https://registry.yarnpkg.com/@porsche-design-system/prettier-config/-/prettier-config-1.0.1.tgz#6b0fc60d3d42c7b4d9c998bf7b685513a5488400"
   integrity sha512-IhoHGmsPoO4VBoCebNGejBNHJFdAldV3m8kAoO458MJeaQJODM2b1UFzvGeTXGOMIFH4pkshcjZcF36vQvsn9w==
 
-"@porsche-design-system/visual-regression-tester@^4.4.0":
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/@porsche-design-system/visual-regression-tester/-/visual-regression-tester-4.4.0.tgz#878a8a47ca3048e79df48ee33e82e5a741d51495"
-  integrity sha512-SJ8hElwFtk+CJISRtpwo0m9fmnYrwR9yTd8KyVVx8X1QxyIE+SDyd7zdiGR+h2kctGmSF6+m9/nZgI9JDUy4pg==
-  dependencies:
-    pixelmatch "^5.3.0"
-    sharp "^0.30.5"
-
 "@porsche-design-system/visual-regression-tester@^4.5.0":
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/@porsche-design-system/visual-regression-tester/-/visual-regression-tester-4.5.0.tgz#50ccba4bb67029936be2ca1d6f576487014ffa92"
@@ -5578,10 +5570,10 @@
     "@webassemblyjs/wast-parser" "1.9.0"
     "@xtuc/long" "4.2.2"
 
-"@webcomponents/template-shadowroot@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@webcomponents/template-shadowroot/-/template-shadowroot-0.1.0.tgz#adb3438d0d9a18e8fced08abc253f56b7eadab00"
-  integrity sha512-ry84Vft6xtRBbd4M/ptRodbOLodV5AD15TYhyRghCRgIcJJKmYmJ2v2BaaWxygENwh6Uq3zTfGPmlckKT/GXsQ==
+"@webcomponents/template-shadowroot@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@webcomponents/template-shadowroot/-/template-shadowroot-0.2.1.tgz#b20182f25f3af9baa9b7cbecce8dd6a7ab7fc39f"
+  integrity sha512-fXL/vIUakyZL62hyvUh+EMwbVoTc0hksublmRz6ai6et8znHkJa6gtqMUZo1oc7dIz46exHSIImml9QTdknMHg==
 
 "@webpack-cli/configtest@^2.0.1":
   version "2.0.1"


### PR DESCRIPTION
### Pull Request Checklist

<!-- Make sure to read and accept the CLA, before you open the pull request: `CONTRIBUTOR_LICENSE_AGREEMENT` -->
<!-- Tick the checkbox in case you accept it (`[x]`) -->

- [x] I have read and accept the [Contributor License Agreement](https://github.com/porscheofficial/oss-docs/blob/67c5b24838a293ce7a964884e6005eb71f2b8579/CONTRIBUTOR_LICENSE_AGREEMENT.md)

#### References

- Preview: https://designsystem.porsche.com/issue/.../

#### Scope

Issue description: https://github.com/orgs/porsche-design-system/projects/10/views/2?pane=issue&itemId=21029596

- Updated "@webcomponents/template-shadowroot" to the latest version - there the new attribute "shadowrootmode" is supported
- Since Chrome supports "shadowrootmode" only starting from version 111 (see [Chromestatus](https://chromestatus.com/feature/5161240576393216) and [PR](https://github.com/whatwg/html/pull/5465) ), we have to support both "shadowroot" and "shadowrootmode", so that it also works in older chrome. Our dsr components have now both: `shadowroot="open" shadowrootmode="open"`
