### PR TITLE
Replace `process` object in UXPin bundle to avoid run-time errors

### DIFF
--- a/packages/components-react/projects/uxpin-wrapper/webpack.config.js
+++ b/packages/components-react/projects/uxpin-wrapper/webpack.config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const webpack = require('webpack');
 
 // Source: https://merge-tech.slack.com/archives/C01SWQ67CSW/p1620356760000200
 module.exports = {
@@ -39,4 +40,9 @@ module.exports = {
       },
     ],
   },
+  plugins: [
+    new webpack.DefinePlugin({
+      process: JSON.stringify({ browser: true }),
+    }),
+  ],
 };


### PR DESCRIPTION
### Pull Request Checklist

<!-- Make sure to read and accept the CLA, before you open the pull request: `CONTRIBUTOR_LICENSE_AGREEMENT` -->
<!-- Tick the checkbox in case you accept it (`[x]`) -->

- [x] I have read and accept the [Contributor License Agreement](https://opensource.porsche.com/docs/cla)

#### References

Fix an error introduced by a recent change in the master,  because `process` object does not exist in the UXPin bundle (details in the issue)

#### Scope

This PR fixes the issue by injecting in the code that runs in UXPin the `process` object, using [Webpack.DefinePlugin](https://webpack.js.org/plugins/define-plugin/) feature.

I checked the result by running UXPin experimental mode in the browser.

#### Resolved Issue

Resolves #2715 
