### PR TITLE
Add focus styles to pre in Storefront (issue/2343)

### DIFF
--- a/packages/storefront/src/components/Markdown.vue
+++ b/packages/storefront/src/components/Markdown.vue
@@ -249,6 +249,7 @@
         }
 
         pre {
+          @include pds-focus();
           margin-top: $pds-spacing-static-small;
           display: block;
           padding: $pds-spacing-static-small $pds-spacing-static-medium;
@@ -259,9 +260,6 @@
           border-radius: $pds-border-radius-medium;
           overflow-x: auto;
           -webkit-overflow-scrolling: touch;
-          &:focus {
-            @include pds-focus();
-          }
         }
 
         // Tables

--- a/packages/storefront/src/components/Markdown.vue
+++ b/packages/storefront/src/components/Markdown.vue
@@ -259,6 +259,9 @@
           border-radius: $pds-border-radius-medium;
           overflow-x: auto;
           -webkit-overflow-scrolling: touch;
+          &:focus {
+            @include pds-focus();
+          }
         }
 
         // Tables


### PR DESCRIPTION
### Pull Request Checklist

<!-- Make sure to read and accept the CLA, before you open the pull request: `CONTRIBUTOR_LICENSE_AGREEMENT` -->
<!-- Tick the checkbox in case you accept it (`[x]`) -->

- [x] I have read and accept the [Contributor License Agreement](https://opensource.porsche.com/docs/cla)

#### References

- Preview: https://designsystem.porsche.com/issue/2343/news/changelog/components

#### Scope

Fixes the wrong outline color of the pre element in the Storefront on focus

#### Resolved Issue

Resolves #2343
