### PR TITLE
[BUG] - PCarousel - Each child in a list should have a unique "key" prop (issue/2990)

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -14,6 +14,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### [Unreleased]
 
+#### Fixed
+
+- `Carousel`: `Each child in a list should have a unique "key" prop` warning in Next.js SSR context
+  ([#3001](https://github.com/porsche-design-system/porsche-design-system/pull/3001))
+
 ### [3.10.0] - 2024-01-17
 
 ### [3.10.0-rc.5] - 2024-01-16

--- a/packages/components/src/components/carousel/carousel.tsx
+++ b/packages/components/src/components/carousel/carousel.tsx
@@ -306,21 +306,24 @@ export class Carousel {
                 Skip carousel entries
               </PrefixedTagNames.pLinkPure>
             )}
-            {this.hasNavigation && [
+            {/* Do not render both buttons conditional in an array, this will cause Next.js SSR to throw Warning: Each child in a list should have a unique "key" prop. */}
+            {this.hasNavigation && (
               <PrefixedTagNames.pButtonPure
                 {...btnProps}
                 icon="arrow-left"
                 ref={(ref) => (this.btnPrev = ref)}
                 onClick={() => slidePrev(this.splide, this.amountOfPages)}
-              />,
+              />
+            )}
+            {this.hasNavigation && (
               <PrefixedTagNames.pButtonPure
                 {...btnProps}
                 icon="arrow-right"
                 ref={(ref) => (this.btnNext = ref)}
                 onClick={() => slideNext(this.splide, this.amountOfPages)}
                 onKeyDown={this.onNextKeyDown}
-              />,
-            ]}
+              />
+            )}
           </div>
         </div>
 


### PR DESCRIPTION
…ix nextjs warning missing key prop | hj | #2990

### Pull Request Checklist

<!-- Make sure to read and accept the CLA, before you open the pull request: `CONTRIBUTOR_LICENSE_AGREEMENT` -->
<!-- Tick the checkbox in case you accept it (`[x]`) -->

- [x] I have read and accept the [Contributor License Agreement](https://opensource.porsche.com/docs/cla)

#### References

- Preview: https://designsystem.porsche.com/issue/2990

#### Scope

Fixes warning `Each child in a list should have a unique "key" prop` when rendering `p-carousel` in Next.js SSR context

#### Resolved Issue

Resolves [#2990](https://github.com/porsche-design-system/porsche-design-system/issues/2990)
