### PR TITLE
[BUG] - Storefront: React syntax highlighting not always working correctly (issue/3159)

### DIFF
--- a/packages/storefront/src/components/CodeBlock.vue
+++ b/packages/storefront/src/components/CodeBlock.vue
@@ -4,13 +4,7 @@
       <!-- prettier-ignore -->
       <button type="button" v-for="(framework, index) in usedFrameworks" :key="index" @click="setFramework(index)">{{ framework }}</button>
     </p-tabs-bar>
-    <pre
-      :class="highlightedLanguage"
-      dir="ltr"
-      tabindex="0"
-      role="region"
-      aria-label="Code sample"
-    ><code v-html="highlightedMarkup"></code></pre>
+    <pre dir="ltr" tabindex="0" role="region" aria-label="Code sample"><code v-html="highlightedMarkup"></code></pre>
   </div>
 </template>
 
@@ -19,7 +13,7 @@
   import Component from 'vue-class-component';
   import { Prop } from 'vue-property-decorator';
   import type { BackgroundColor, Framework, FrameworkMarkup, PlaygroundTheme } from '@/models';
-  import { convertMarkup, getHighlightedCode, getHighlightedLanguage } from '@/utils';
+  import { convertMarkup, getHighlightedCode } from '@/utils';
   import { frameworkNameMap } from '@/utils/frameworkNameMap';
 
   @Component
@@ -59,10 +53,6 @@
         this.frameworkBeforeShared = this.framework;
       }
       this.$store.commit('setSelectedFramework', framework);
-    }
-
-    get highlightedLanguage(): string {
-      return getHighlightedLanguage(this.framework);
     }
 
     get highlightedMarkup(): string {

--- a/packages/storefront/src/utils/code-highlighting.ts
+++ b/packages/storefront/src/utils/code-highlighting.ts
@@ -4,17 +4,6 @@ import 'prismjs/components/prism-markup';
 import { highlight, languages } from 'prismjs';
 import type { Framework } from '@/models';
 
-export const getHighlightedLanguage = (framework: Framework): string => {
-  switch (framework) {
-    case 'react':
-    case 'shared':
-      return 'language-jsx';
-
-    default:
-      return 'markup';
-  }
-};
-
 export const getHighlightedCode = (markup: string, framework: Framework): string => {
   switch (framework) {
     case 'react':

--- a/packages/storefront/tests/e2e/specs/playground.e2e.ts
+++ b/packages/storefront/tests/e2e/specs/playground.e2e.ts
@@ -1,0 +1,62 @@
+import { expect, test } from '@playwright/test';
+import { initConsoleObserver } from '../helpers';
+
+test.beforeEach(async ({ page }) => {
+  initConsoleObserver(page);
+});
+
+test('should have working playground tabs and syntax highlight', async ({ page }) => {
+  await page.goto('/components/button/examples#variants');
+  await page.evaluate(() => (window as any).componentsReady());
+
+  const selectedTab = await page.getByRole('tab', { selected: true }).first();
+  expect(await selectedTab.textContent()).toBe('Vanilla JS');
+
+  await page.getByRole('tab', { name: 'Angular' }).first().click();
+  const selectedTabSecond = await page.getByRole('tab', { selected: true }).first();
+  expect(await selectedTabSecond.textContent()).toBe('Angular');
+
+  const code = page.getByLabel('Code sample').first();
+  expect(code.getByRole('code')).toBeDefined();
+  const codeExample = code.getByText('p-button').first();
+  expect(codeExample).toBeDefined();
+  await expect(codeExample).toHaveCSS('color', 'rgb(0, 114, 153)');
+
+  await page.getByRole('tab', { name: 'React' }).first().click();
+
+  const code2 = page.getByLabel('Code sample').first();
+  expect(code2.getByRole('code')).toBeDefined();
+  const codeExample2 = code2.getByText('PButton').first();
+  expect(codeExample2).toBeDefined();
+  await expect(codeExample2).toHaveCSS('color', 'rgb(0, 114, 153)');
+});
+
+test('should have working playground tabs and syntax highlight when initially selectedFramework is react', async ({
+  page,
+}) => {
+  await page.goto('/');
+  const innerLocalStorage = await page.evaluateHandle(() => window.localStorage);
+  await innerLocalStorage.evaluate((storage) => storage.setItem('selectedFramework', 'react'));
+
+  await page.goto('/components/button/examples#variants');
+  await page.evaluate(() => (window as any).componentsReady());
+
+  const selectedTab = await page.getByRole('tab', { selected: true }).first();
+  expect(await selectedTab.textContent()).toBe('React');
+
+  const code = page.getByLabel('Code sample').first();
+  expect(code.getByRole('code')).toBeDefined();
+  const codeExample = code.getByText('PButton').first();
+  expect(codeExample).toBeDefined();
+  await expect(codeExample).toHaveCSS('color', 'rgb(0, 114, 153)');
+
+  await page.getByRole('tab', { name: 'Vue' }).first().click();
+  const selectedTabSecond = await page.getByRole('tab', { selected: true }).first();
+  expect(await selectedTabSecond.textContent()).toBe('Vue');
+
+  const code2 = page.getByLabel('Code sample').first();
+  expect(code2.getByRole('code')).toBeDefined();
+  const codeExample2 = code2.getByText('PButton').first();
+  expect(codeExample2).toBeDefined();
+  await expect(codeExample2).toHaveCSS('color', 'rgb(0, 114, 153)');
+});


### PR DESCRIPTION
…example | hj | #3159

### Pull Request Checklist

<!-- Make sure to read and accept the CLA, before you open the pull request: `CONTRIBUTOR_LICENSE_AGREEMENT` -->
<!-- Tick the checkbox in case you accept it (`[x]`) -->

- [x] I have read and accept the [Contributor License Agreement](https://opensource.porsche.com/docs/cla)

#### References

- Preview: https://designsystem.porsche.com/issue/3159/components/button/examples

#### Scope

Fix broken storefront when reloading with react as framework selected.

#### Resolved Issue

Resolves [#3159](https://github.com/porsche-design-system/porsche-design-system/issues/3159)
