### PR TITLE
[BUG] - Storefront: Inline CSS variables aren't shown correctly (issue/3160)

### DIFF
--- a/packages/storefront/src/utils/convertToReact.ts
+++ b/packages/storefront/src/utils/convertToReact.ts
@@ -43,7 +43,11 @@ export const transformStyleAttribute = (markup: string): string =>
     const pairs = $style.split(',').map((p) => {
       const [prop, val] = p.split(':').map((x) => x.trim());
       const value = val.match(/^\d+(?:\.\d+)?$/) ? val : `'${val}'`; // numbers don't need quotes
-      return `${camelCase(prop)}: ${value}`;
+
+      // Check if the property is a custom css property
+      const property = prop.startsWith('--') ? `"${prop}"` : camelCase(prop);
+
+      return `${property}: ${value}`;
     });
 
     return ` style={{ ${pairs.join(', ')} }}`;

--- a/packages/storefront/tests/unit/convertToReact.spec.ts
+++ b/packages/storefront/tests/unit/convertToReact.spec.ts
@@ -26,7 +26,7 @@ describe('transformObjectValues()', () => {
   <span>Some text</span>
   <input type="checkbox">
   <button type="button"></button>
-</p-some-tag>`,
+</p-some-tag>`
     );
   });
 });
@@ -38,15 +38,15 @@ describe('transformStandardAttributes()', () => {
   <span>Some text</span>
   <input type="checkbox">
   <button type="button"></button>
-</p-some-tag>`,
+</p-some-tag>`
     );
   });
 
   it('should not transform aria attributes', () => {
     expect(
       transformStandardAttributes(
-        '<div aria-label="some label" aria-checked="false" aria-disabled="false" aria-live="polite"></div>',
-      ),
+        '<div aria-label="some label" aria-checked="false" aria-disabled="false" aria-live="polite"></div>'
+      )
     ).toBe('<div aria-label="some label" aria-checked="false" aria-disabled="false" aria-live="polite"></div>');
   });
 
@@ -60,19 +60,19 @@ describe('transformStandardAttributes()', () => {
 
   it('should not transform readonly innerText to camelCase', () => {
     expect(transformStandardAttributes('<label>Some readonly label</label>')).toBe(
-      '<label>Some readonly label</label>',
+      '<label>Some readonly label</label>'
     );
   });
 
   it('should transform maxlength attribute to camelCase', () => {
     expect(transformStandardAttributes('<input type="text" maxlength="20">')).toBe(
-      '<input type="text" maxLength="20">',
+      '<input type="text" maxLength="20">'
     );
   });
 
   it('should not transform maxlength innerText to camelCase', () => {
     expect(transformStandardAttributes('<label>Some maxlength label</label>')).toBe(
-      '<label>Some maxlength label</label>',
+      '<label>Some maxlength label</label>'
     );
   });
 
@@ -82,13 +82,13 @@ describe('transformStandardAttributes()', () => {
 
   it('should transform srcset attribute to camelCase for img tag', () => {
     expect(transformStandardAttributes('<img src="./some_png.png" srcset="./some_png.png">')).toBe(
-      '<img src="./some_png.png" srcSet={"./some_png.png"}>',
+      '<img src="./some_png.png" srcSet={"./some_png.png"}>'
     );
   });
 
   it('should transform srcset attribute to camelCase for source tag', () => {
     expect(transformStandardAttributes('<source src="./some_png.png" srcset="./some_png.png">')).toBe(
-      '<source src="./some_png.png" srcSet={"./some_png.png"}>',
+      '<source src="./some_png.png" srcSet={"./some_png.png"}>'
     );
   });
 });
@@ -100,7 +100,7 @@ describe('transformClassAttribute()', () => {
   <span>Some text</span>
   <input type="checkbox">
   <button type="button"></button>
-</p-some-tag>`,
+</p-some-tag>`
     );
   });
 });
@@ -112,13 +112,13 @@ describe('transformEvents()', () => {
   <span>Some text</span>
   <input type="checkbox">
   <button type="button"></button>
-</p-some-tag>`,
+</p-some-tag>`
     );
   });
 
   it('should not transform attribute values containing " on"', () => {
     expect(transformEvents('<p-somme-tag label="Icon only" icon="user"></p-somme-tag>')).toBe(
-      `<p-somme-tag label="Icon only" icon="user"></p-somme-tag>`,
+      `<p-somme-tag label="Icon only" icon="user"></p-somme-tag>`
     );
   });
 });
@@ -130,24 +130,24 @@ describe('transformBooleanDigitAndUndefinedValues()', () => {
   <span>Some text</span>
   <input type="checkbox">
   <button type="button"></button>
-</p-some-tag>`,
+</p-some-tag>`
     );
   });
 
   it('should remove quotes and add brackets to undefined values', () => {
     expect(transformBooleanDigitAndUndefinedValues(`<p-some-tag attribute="undefined"></p-some-tag>`)).toBe(
-      `<p-some-tag attribute={undefined}></p-some-tag>`,
+      `<p-some-tag attribute={undefined}></p-some-tag>`
     );
   });
 
   it('should not transform prop model with digit values', () => {
     expect(transformAttributesWithDigitValue('<p-model-signature model="911"></p-model-signature>')).toBe(
-      `<p-model-signature [model]="'911'"></p-model-signature>`,
+      `<p-model-signature [model]="'911'"></p-model-signature>`
     );
   });
   it('should not transform pin codes prop value with digit values', () => {
     expect(transformAttributesWithDigitValue('<p-pin-code value="1234"></p-pin-code>')).toBe(
-      `<p-pin-code [value]="'1234'"></p-pin-code>`,
+      `<p-pin-code [value]="'1234'"></p-pin-code>`
     );
   });
 });
@@ -159,7 +159,7 @@ describe('transformCustomElementTagName()', () => {
   <span>Some text</span>
   <input type="checkbox">
   <button type="button"></button>
-</PSomeTag>`,
+</PSomeTag>`
     );
   });
 
@@ -174,7 +174,7 @@ describe('transformCustomElementTagName()', () => {
   attribute="some value"
   class="some-class"
 >
-</PSomeTag>`,
+</PSomeTag>`
     );
   });
 
@@ -191,7 +191,7 @@ describe('transformInputs()', () => {
   <span>Some text</span>
   <input type="checkbox" />
   <button type="button"></button>
-</p-some-tag>`,
+</p-some-tag>`
     );
   });
 });
@@ -203,7 +203,7 @@ describe('transformToSelfClosingTags()', () => {
   <span>Some text</span>
   <input type="checkbox">
   <button type="button" />
-</p-some-tag>`,
+</p-some-tag>`
     );
   });
 
@@ -222,17 +222,17 @@ describe('transformToSelfClosingTags()', () => {
 describe('transformStyleAttribute()', () => {
   it('should quote values', () => {
     const markup = '<div style="display: block"></div>';
-    expect(transformStyleAttribute(markup)).toBe('<div style={{ display: \'block\' }}></div>');
+    expect(transformStyleAttribute(markup)).toBe("<div style={{ display: 'block' }}></div>");
   });
 
   it('should transform properties to camelCase', () => {
     const markup = '<div style="text-align: center"></div>';
-    expect(transformStyleAttribute(markup)).toBe('<div style={{ textAlign: \'center\' }}></div>');
+    expect(transformStyleAttribute(markup)).toBe("<div style={{ textAlign: 'center' }}></div>");
   });
 
   it('should handle multiple styles', () => {
     const markup = '<div style="text-align: center; font-size: 16px"></div>';
-    expect(transformStyleAttribute(markup)).toBe('<div style={{ textAlign: \'center\', fontSize: \'16px\' }}></div>');
+    expect(transformStyleAttribute(markup)).toBe("<div style={{ textAlign: 'center', fontSize: '16px' }}></div>");
   });
 
   it('should handle multiline style', () => {
@@ -250,8 +250,16 @@ describe('transformStyleAttribute()', () => {
 
   it('should correctly convert number values', () => {
     expect(transformStyleAttribute('<div style="font-size: 60px; line-height: 1.5; font-weight: 100"></div>')).toBe(
-      `<div style={{ fontSize: '60px', lineHeight: 1.5, fontWeight: 100 }}></div>`,
+      `<div style={{ fontSize: '60px', lineHeight: 1.5, fontWeight: 100 }}></div>`
     );
+  });
+
+  it('should correctly convert custom css properties', () => {
+    expect(
+      transformStyleAttribute(
+        '<div style="--some-custom-property: 60px; --some-additional-custom-property: 1.5;"></div>'
+      )
+    ).toBe(`<div style={{ "--some-custom-property": '60px', "--some-additional-custom-property": 1.5 }}></div>`);
   });
 });
 
@@ -293,7 +301,7 @@ describe('convertToReact()', () => {
   <span>Some text</span>
   <input type="checkbox" />
   <button type="button" />
-</PSomeTag>`,
+</PSomeTag>`
     );
   });
 });


### PR DESCRIPTION
…hj | #3160

### Pull Request Checklist

<!-- Make sure to read and accept the CLA, before you open the pull request: `CONTRIBUTOR_LICENSE_AGREEMENT` -->
<!-- Tick the checkbox in case you accept it (`[x]`) -->

- [x] I have read and accept the [Contributor License Agreement](https://opensource.porsche.com/docs/cla)

#### References

- Preview: https://designsystem.porsche.com/issue/3160

#### Scope

CSS custom properties are not converted correctly in react markup. See https://designsystem.porsche.com/issue/3160/components/model-signature/examples#custom-styling

#### Resolved Issue

Resolves [#3160](https://github.com/porsche-design-system/porsche-design-system/issues/3160)
