### PR TITLE
Fix banner position on mobile (issue/3129)

### DIFF
--- a/packages/components/src/components/banner/banner-styles.ts
+++ b/packages/components/src/components/banner/banner-styles.ts
@@ -33,6 +33,7 @@ export const getComponentCss = (isOpen: boolean): string => {
         display: 'block',
         ...addImportantToEachRule({
           ...getBannerPopoverResetStyles(),
+          top: 'auto',
           bottom: `var(${cssVariableBottom},${topBottomFallback})`,
           left: gridExtendedOffsetBase,
           right: gridExtendedOffsetBase,


### PR DESCRIPTION
### Pull Request Checklist

<!-- Make sure to read and accept the CLA, before you open the pull request: `CONTRIBUTOR_LICENSE_AGREEMENT` -->
<!-- Tick the checkbox in case you accept it (`[x]`) -->

- [x] I have read and accept the [Contributor License Agreement](https://opensource.porsche.com/docs/cla)

#### References

- Preview: https://designsystem.porsche.com/issue/3129/

#### Scope

Since the banner is now a top-layer element, the top-position needs to be reset in order to eliminate the inset style coming from the browser to display the banner on the bottom.

#### Resolved Issue

Resolves #3129
