### PR TITLE
[BUG] Refactor parseJSONAttribute to support Safari < 16.4 (issue/3313)

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -14,6 +14,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0), 
 
 ### [Unreleased]
 
+#### Fixed
+
+- `aria`: Refactor `parseJSONAttribute` to support Safari < 16.4  
+  ([#3314](https://github.com/porsche-design-system/porsche-design-system/pull/3314))
+
 ### [3.15.1] - 2024-05-23
 
 #### Fixed

--- a/packages/components/src/utils/json.ts
+++ b/packages/components/src/utils/json.ts
@@ -4,17 +4,15 @@ export const parseJSONAttribute = <T>(attribute: T | string): T => {
     return attribute;
   }
 
-  // Convert single quotes to double quotes except the ones which are escaped by backslash
-  let jsonString = attribute
-    .replace(/\\'/g, '__escaped_single_quote__')
-    .replace(/'/g, '"')
-    .replace(/__escaped_single_quote__/g, '\\\'');
-
-  // Remove string escapes except the ones followed by unicode u0027
-  jsonString = jsonString.replace(/([^\\])\\(?!u0027)/g, '$1');
-
-  // Wrap keys in double quotes
-  jsonString = jsonString.replace(/[\s"]?([\w-]+)[\s"]?:/g, '"$1":');
-
-  return JSON.parse(jsonString);
+  return JSON.parse(
+    attribute
+      // Convert single quotes to double quotes except the ones which are escaped by backslash
+      .replace(/\\'/g, '__escaped_single_quote__')
+      .replace(/'/g, '"')
+      .replace(/__escaped_single_quote__/g, '\\\'')
+      // Remove string escapes except the ones followed by unicode u0027
+      .replace(/([^\\])\\(?!u0027)/g, '$1')
+      // Wrap keys in double quotes
+      .replace(/[\s"]?([\w-]+)[\s"]?:/g, '"$1":')
+  );
 };

--- a/packages/components/src/utils/json.ts
+++ b/packages/components/src/utils/json.ts
@@ -1,12 +1,20 @@
 export const parseJSONAttribute = <T>(attribute: T | string): T => {
-  return typeof attribute === 'string'
-    ? // input is potentially JSON parsable string, e.g. "{ 'aria-label': 'Some label' }"
-      JSON.parse(
-        attribute
-          .replace(/(?<!\\)'/g, '"') // convert single quotes to double quotes except the ones which are escaped by backslash
-          .replace(/\\(?!u0027)/g, '') // remove string escapes except the ones followed by unicode u0027
-          .replace(/[\s"]?([\w-]+)[\s"]?:/g, '"$1":') // wrap keys in double quotes
-      )
-    : // input is object, e.g. { 'aria-label': 'Some label' }
-      attribute;
+  // Input is object, e.g. { 'aria-label': 'Some label' }
+  if (typeof attribute !== 'string') {
+    return attribute;
+  }
+
+  // Convert single quotes to double quotes except the ones which are escaped by backslash
+  let jsonString = attribute
+    .replace(/\\'/g, '__escaped_single_quote__')
+    .replace(/'/g, '"')
+    .replace(/__escaped_single_quote__/g, '\\\'');
+
+  // Remove string escapes except the ones followed by unicode u0027
+  jsonString = jsonString.replace(/([^\\])\\(?!u0027)/g, '$1');
+
+  // Wrap keys in double quotes
+  jsonString = jsonString.replace(/[\s"]?([\w-]+)[\s"]?:/g, '"$1":');
+
+  return JSON.parse(jsonString);
 };


### PR DESCRIPTION
### Pull Request Checklist

<!-- Make sure to read and accept the CLA, before you open the pull request: `CONTRIBUTOR_LICENSE_AGREEMENT` -->
<!-- Tick the checkbox in case you accept it (`[x]`) -->

- [x] I have read and accept the [Contributor License Agreement](https://opensource.porsche.com/docs/cla)

#### References

- Preview: https://designsystem.porsche.com/issue/3313/

#### Scope

By avoiding using regex lookbehinds the function is working again in Safari < 16.4

#### Resolved Issue

Resolves #3313
