### PR TITLE
[BUG] - missing @deprecrated annotations (issue/3499)

### DIFF
--- a/packages/components/scripts/wrapper-generator/InputParser.ts
+++ b/packages/components/scripts/wrapper-generator/InputParser.ts
@@ -95,8 +95,8 @@ export class InputParser {
 
   public getDeprecationMessage(component: TagName): string {
     const fileContent = this.getComponentSourceCode(component);
-    const [deprecated, rawDeprecationMessage = ''] =
-      /\/\*\* @deprecated (.*)\*\/\n@Component\({/.exec(fileContent) || [];
+    // Regex does not work for multiline deprecation message
+    const [deprecated, rawDeprecationMessage = ''] = /@deprecated ([^*]*)[\s\S]*?@Component/.exec(fileContent) || [];
 
     return !!deprecated ? `/** @deprecated ${rawDeprecationMessage.trim()} */\n` : '';
   }


### PR DESCRIPTION
### Pull Request Checklist

<!-- Make sure to read and accept the CLA, before you open the pull request: `CONTRIBUTOR_LICENSE_AGREEMENT` -->
<!-- Tick the checkbox in case you accept it (`[x]`) -->

- [x] I have read and accept the [Contributor License Agreement](https://opensource.porsche.com/docs/cla)

#### References

- Preview: https://designsystem.porsche.com/issue/3499

#### Scope

it looks like @deprecated annotations for components got lost with 3.17.0 at least for components-react, most likely same for other packages that rely on InputParser.getDeprecationMessage().
They were still there with 3.16.0.

#### Resolved Issue

Resolves #3499
