### PR TITLE
Remove spacing props, support for uxpin custom props, set fit to content as default for every component

### DIFF
--- a/packages/components/scripts/wrapper-generator/UXPinReactWrapperGenerator.ts
+++ b/packages/components/scripts/wrapper-generator/UXPinReactWrapperGenerator.ts
@@ -14,8 +14,6 @@ const addNestedIndentation = (x: string): string => `  ${x}`;
 export class UXPinReactWrapperGenerator extends ReactWrapperGenerator {
   protected projectDir = 'uxpin-wrapper';
 
-  private spacingProps: string[] = ['top', 'left', 'right', 'bottom'].map((x) => `spacing${pascalCase(x)}`);
-
   constructor() {
     super();
     this.ignoreComponents = [
@@ -49,11 +47,6 @@ export class UXPinReactWrapperGenerator extends ReactWrapperGenerator {
     } else if (component === 'p-text') {
       imports = imports.replace(/, TextSize/, '');
     }
-
-    // add spacing imports
-    imports += ['import type { Spacing }', 'import { getPaddingStyles }']
-      .map((imp, i) => `${i === 0 ? '\n' : ''}${imp} from '../../spacing';`)
-      .join('\n');
 
     // when component is nested we need to fix relative imports
     if (this.shouldGenerateFolderPerComponent(component)) {
@@ -146,10 +139,6 @@ export class UXPinReactWrapperGenerator extends ReactWrapperGenerator {
       props = addUxPinBindAnnotation(props, 'activeTabIndex', 'onTabChange', 'activeTabIndex');
     }
 
-    // add spacing props to every component
-    const spacings = this.spacingProps.map((x) => `${x}?: Spacing;`).join('\n  ');
-    props = props.replace(/BaseProps & \{\n/, `$&  ${spacings}\n`);
-
     return props;
   }
 
@@ -161,16 +150,6 @@ export class UXPinReactWrapperGenerator extends ReactWrapperGenerator {
       .replace(/\s+class.*/, ''); // remove class mapping via useMergedClass since it is useless
 
     cleanedComponent = this.insertComponentAnnotation(cleanedComponent, component);
-
-    // destructure spacing props
-    const spacings = this.spacingProps.join(', ');
-    cleanedComponent = cleanedComponent.replace(/(\.\.\.rest)/, `${spacings}, $1`);
-
-    // build inline style prop
-    cleanedComponent = cleanedComponent.replace(
-      /(\.\.\.rest,\n)/,
-      `$1      style: getPaddingStyles({ ${spacings} }),\n`
-    );
 
     // add default children for components that need it
     if (cleanedComponent.includes('PropsWithChildren')) {
@@ -329,7 +308,7 @@ export class UXPinReactWrapperGenerator extends ReactWrapperGenerator {
         props: { heading: 'Heading', open: true },
         children: [
           '<Text uxpId="modal-text">Some Content</Text>',
-          '<ButtonGroup uxpId="modal-button-group" spacingTop={32}>',
+          '<ButtonGroup uxpId="modal-button-group" >',
           ...[
             '<Button uxpId="modal-button-1" children="Save" />',
             '<Button uxpId="modal-button-2" variant="tertiary" children="Close" />',
@@ -586,6 +565,7 @@ export default <${formComponentName} ${stringifiedProps} />;
     webpackConfig: 'webpack.config.js',
   },
   name: 'Porsche Design System',
+  settings: { useUXPinProps: true, useFitToContentAsDefault: true },
 };`;
 
     return { name: 'uxpin.config.js', relativePath: '../../..', content };


### PR DESCRIPTION


### Pull Request Checklist

<!-- Make sure to read and accept the CLA, before you open the pull request: `CONTRIBUTOR_LICENSE_AGREEMENT` -->
<!-- Tick the checkbox in case you accept it (`[x]`) -->

- [x] I have read and accept the [Contributor License Agreement](https://opensource.porsche.com/docs/cla)

#### References

Requests from @marcelbertram


#### Scope
- added useUXPinProps which adds custom styles and custom props to every component
- removed spacing properties <- this is replaced by the padding property in custom styles
- added use useFitToContentAsDefault, which sets 
 property to true when you drop an element from the library on canvas

https://github.com/user-attachments/assets/cb38d73f-f6c6-4cdf-9195-a62a65d31419


