### PR TITLE
Better tree-shaking support for components-react

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -14,6 +14,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0), 
 
 ### [Unreleased]
 
+#### Added
+
+- React: better tree-shaking for `@porsche-design-system/components-react`
+  ([#3554](https://github.com/porsche-design-system/porsche-design-system/pull/3554))
+
 ### [3.20.0-rc.0] - 2024-10-18
 
 #### Added

--- a/packages/components/scripts/wrapper-generator/ReactWrapperGenerator.ts
+++ b/packages/components/scripts/wrapper-generator/ReactWrapperGenerator.ts
@@ -125,7 +125,7 @@ export class ReactWrapperGenerator extends AbstractWrapperGenerator {
 
     const genericType = hasGeneric ? '<T extends object>' : '';
 
-    return `${this.inputParser.getDeprecationMessage(component)}export const ${pascalCase(component)} = forwardRef(
+    return `${this.inputParser.getDeprecationMessage(component)}export const ${pascalCase(component)} = /*#__PURE__*/ forwardRef(
   ${genericType}(
     ${wrapperProps}: ${wrapperPropsType},
     ref: ForwardedRef<HTMLElement>


### PR DESCRIPTION
When bundling with vite, for both, default `minify: 'esbuild` and `minify: 'terser'` (https://vite.dev/config/build-options#build-minify) unused react wrappers are bundled into the final build.

This is fixed by having `/*#__PURE__*/` annotations.

### Pull Request Checklist

<!-- Make sure to read and accept the CLA, before you open the pull request: `CONTRIBUTOR_LICENSE_AGREEMENT` -->
<!-- Tick the checkbox in case you accept it (`[x]`) -->

- [x] I have read and accept the [Contributor License Agreement](https://opensource.porsche.com/docs/cla)

#### Scope

```
before: build/assets/index-oMBl56lH.js                  1,506.11 kB │ gzip: 441.94 kB
after:  build/assets/index-CHF0lILj.js                  1,493.71 kB │ gzip: 439.45 kB
```

**before**
<img width="616" alt="Bildschirmfoto 2024-10-23 um 09 35 15" src="https://github.com/user-attachments/assets/0734df39-08bb-4d9f-be92-1ff41dbd5da2">

<img width="1678" alt="Bildschirmfoto 2024-10-23 um 09 57 55" src="https://github.com/user-attachments/assets/46c7a914-d3f8-4c58-9aa0-2fe8e18c7674">

**after**
<img width="1668" alt="Bildschirmfoto 2024-10-23 um 09 56 39" src="https://github.com/user-attachments/assets/db957480-f514-4ed7-9391-9fe370b70dd1">

