### PR TITLE
Make pin code controlled - value property will be automatically updated on every change on uxpin side

### DIFF
--- a/packages/components/scripts/wrapper-generator/UXPinReactWrapperGenerator.ts
+++ b/packages/components/scripts/wrapper-generator/UXPinReactWrapperGenerator.ts
@@ -103,6 +103,11 @@ export class UXPinReactWrapperGenerator extends ReactWrapperGenerator {
     // remove BreakpointCustomizable types since designers can't use JSON
     props = props.replace(/BreakpointCustomizable<(.*)>/g, '$1');
 
+
+    // hidden uxpin props which allows updating property from library level in uxpin editor
+    props = addProp(props, '/** @uxpinignoreprop */ \n  uxpinOnChange?: (prevValue: any, nextValue: any, propertyName: string) => void;');
+
+
     // remove useless props
     if (component === 'p-marque') {
       props = removeProp(props, 'href');
@@ -219,6 +224,21 @@ export class UXPinReactWrapperGenerator extends ReactWrapperGenerator {
     } else if (component === 'p-marque') {
       cleanedComponent = removeDestructuredProp(cleanedComponent, 'href');
       cleanedComponent = removeDestructuredProp(cleanedComponent, 'target');
+    }
+
+    if (component === 'p-pin-code') {
+      cleanedComponent = cleanedComponent.replace(
+          'useEventCallback(elementRef, \'update\', onUpdate as any);',
+          [
+              'const eventCallback = (e: CustomEvent<PinCodeUpdateEventDetail>) => {',
+              '       rest.uxpinOnChange(value, e.detail.value, \'value\');',
+              '       if (onUpdate) {',
+              '         onUpdate(e);',
+              '       }',
+              '    }',
+              '    useEventCallback(elementRef, \'update\', eventCallback);',
+          ].join('\n')
+      )
     }
 
     // cast BreakpointCustomizable default prop values to any because BreakpointCustomizable types are removed for uxpin

--- a/packages/components/scripts/wrapper-generator/UXPinReactWrapperGenerator.ts
+++ b/packages/components/scripts/wrapper-generator/UXPinReactWrapperGenerator.ts
@@ -105,7 +105,7 @@ export class UXPinReactWrapperGenerator extends ReactWrapperGenerator {
 
 
     // hidden uxpin props which allows updating property from library level in uxpin editor
-    props = addProp(props, '/** @uxpinignoreprop */ \n  uxpinOnChange?: (prevValue: any, nextValue: any, propertyName: string) => void;');
+    props = addProp(props, '/** @uxpinignoreprop */ \n  uxpinOnChange: (prevValue: any, nextValue: any, propertyName: string) => void;');
 
 
     // remove useless props
@@ -230,7 +230,7 @@ export class UXPinReactWrapperGenerator extends ReactWrapperGenerator {
       cleanedComponent = cleanedComponent.replace(
           'useEventCallback(elementRef, \'update\', onUpdate as any);',
           [
-              'const eventCallback = (e: CustomEvent<PinCodeUpdateEventDetail>) => {',
+              'const eventCallback = (e) => {',
               '       rest.uxpinOnChange(value, e.detail.value, \'value\');',
               '       if (onUpdate) {',
               '         onUpdate(e);',

--- a/packages/components/scripts/wrapper-generator/UXPinReactWrapperGenerator.ts
+++ b/packages/components/scripts/wrapper-generator/UXPinReactWrapperGenerator.ts
@@ -230,10 +230,10 @@ export class UXPinReactWrapperGenerator extends ReactWrapperGenerator {
       cleanedComponent = cleanedComponent.replace(
           'useEventCallback(elementRef, \'update\', onUpdate as any);',
           [
-              'const eventCallback = (e) => {',
-              '       rest.uxpinOnChange(value, e.detail.value, \'value\');',
+              'const eventCallback = (e:Event) => {',
+              '       rest.uxpinOnChange(value, (e as CustomEvent<PinCodeUpdateEventDetail>).detail.value, \'value\');',
               '       if (onUpdate) {',
-              '         onUpdate(e);',
+              '         onUpdate(e as CustomEvent<PinCodeUpdateEventDetail>);',
               '       }',
               '    }',
               '    useEventCallback(elementRef, \'update\', eventCallback);',


### PR DESCRIPTION

### Pull Request Checklist

<!-- Make sure to read and accept the CLA, before you open the pull request: `CONTRIBUTOR_LICENSE_AGREEMENT` -->
<!-- Tick the checkbox in case you accept it (`[x]`) -->

- [x] I have read and accept the [Contributor License Agreement](https://opensource.porsche.com/docs/cla)

#### References

@marcelbertram request:

> Pin Code provide value for interactions and conditions


#### Scope

I added the `uxpinOnChange` property to each component. This function enables updates to various properties on the UXPin side, allowing the components to become controlled. In the PinCode component, I utilized `uxpinOnChange` within the `update` event, so now whenever a user changes the PinCode value, the value property will automatically update.

https://github.com/user-attachments/assets/194c281c-35b0-4969-a08c-f944b3d33204


