### PR TITLE
Automatically close flyout on dismiss event

### DIFF
--- a/packages/components/scripts/wrapper-generator/UXPinReactWrapperGenerator.ts
+++ b/packages/components/scripts/wrapper-generator/UXPinReactWrapperGenerator.ts
@@ -241,6 +241,21 @@ export class UXPinReactWrapperGenerator extends ReactWrapperGenerator {
       )
     }
 
+    if (component === 'p-flyout') {
+      cleanedComponent = cleanedComponent.replace(
+          'useEventCallback(elementRef, \'dismiss\', onDismiss as any);',
+          [
+            'const dismissCallback = (e:Event) => {',
+            '       rest.uxpinOnChange(open, false, \'open\');',
+            '       if (onDismiss) {',
+            '         onDismiss(e as CustomEvent<void>);',
+            '       }',
+            '    }',
+            '    useEventCallback(elementRef, \'dismiss\', dismissCallback);',
+          ].join('\n')
+      )
+    }
+
     // cast BreakpointCustomizable default prop values to any because BreakpointCustomizable types are removed for uxpin
     extendedProps
       .filter((prop) => prop.isDefaultValueComplex && prop.defaultValue.match(/\bbase\b/))


### PR DESCRIPTION
### Pull Request Checklist

<!-- Make sure to read and accept the CLA, before you open the pull request: `CONTRIBUTOR_LICENSE_AGREEMENT` -->
<!-- Tick the checkbox in case you accept it (`[x]`) -->

- [x] I have read and accept the [Contributor License Agreement](https://opensource.porsche.com/docs/cla)

#### References

@marcelbertram request:

Flyout backdrop click not working for closing and dismiss should be preconfigured to trigger visibility hidden

#### Scope

I call uxpinOnChange method on dismiss event which sets `open` property to false


https://github.com/user-attachments/assets/3b687341-12db-425a-91f1-97030f01ecb3


