### PR TITLE
introduce property configurations which allows disabling property for…

### DIFF
--- a/packages/components/scripts/wrapper-generator/UXPinReactWrapperGenerator.ts
+++ b/packages/components/scripts/wrapper-generator/UXPinReactWrapperGenerator.ts
@@ -611,7 +611,18 @@ export default <${formComponentName} ${stringifiedProps} />;
     webpackConfig: 'webpack.config.js',
   },
   name: 'Porsche Design System',
-  settings: { useUXPinProps: true, useFitToContentAsDefault: true },
+  settings: { 
+    useUXPinProps: true, 
+    useFitToContentAsDefault: true,
+    propertyConfigurations: {
+      Flyout: {
+        open: { disabled: true, context: 'canvas', value: false, },
+      },
+      Modal: {
+        open: { disabled: true, context: 'canvas', value: false },
+      }
+    }
+  },
 };`;
 
     return { name: 'uxpin.config.js', relativePath: '../../..', content };


### PR DESCRIPTION
… given context

### Pull Request Checklist

<!-- Make sure to read and accept the CLA, before you open the pull request: `CONTRIBUTOR_LICENSE_AGREEMENT` -->
<!-- Tick the checkbox in case you accept it (`[x]`) -->

- [x] I have read and accept the [Contributor License Agreement](https://opensource.porsche.com/docs/cla)

#### References

Handling overlay components like modal and flyout only within a frame
When using overlay components like flyout and modal it is breaking the edit mode because it overlays the editor view. 

#### Scope

I added propertyConfigurations option in library settings where we can set which property can be disabled in given context

Type of propertyConfiguration
 ```{
    [componentName: string]: {
      [propertyName: string]: {
        disabled: boolean;
        value: any; // value which will be set when property is disabled
        context: 'canvas' | 'frame';
      };
    };
  };
```

this is how it looks

https://github.com/user-attachments/assets/c92d7a0e-3b57-406d-8a15-c0711928599a

It does not work in experimental mode because library settings are not handled there. If you want test please push library to uxpin

