### PR TITLE
handle onClick property in crest component, bring back DummyButton as…

### DIFF
--- a/packages/components/scripts/wrapper-generator/UXPinReactWrapperGenerator.ts
+++ b/packages/components/scripts/wrapper-generator/UXPinReactWrapperGenerator.ts
@@ -4,6 +4,7 @@ import { ReactWrapperGenerator } from './ReactWrapperGenerator';
 import type { ExtendedProp } from './DataStructureBuilder';
 import type { AdditionalFile } from './AbstractWrapperGenerator';
 import { kebabCase, pascalCase } from 'latest-change-case';
+import {useBrowserLayoutEffect} from "../../../components-react/projects/uxpin-wrapper/src/hooks";
 
 type PresetsProps = { [key: string]: number | string | boolean | string[] | object | null };
 
@@ -113,7 +114,7 @@ export class UXPinReactWrapperGenerator extends ReactWrapperGenerator {
     }
 
     // add onClick prop for marque, buttons and links, but not button-group
-    else if (!!component.match(/(button|link|marque|stepper-horizontal-item|tag-dismissible)(?!-group)/)) {
+    else if (!!component.match(/(button|link|marque|stepper-horizontal-item|tag-dismissible|crest)(?!-group)/)) {
       props = addProp(props, 'onClick?: (e: MouseEvent) => void;');
     }
 
@@ -142,8 +143,9 @@ export class UXPinReactWrapperGenerator extends ReactWrapperGenerator {
     // add uxpinignoreprop annotations
     if (component === 'p-modal') {
       props = addUxPinIgnorePropAnnotation(props, 'open');
-    } else if (component === 'p-link' || component === 'p-link-pure' || component === 'p-link-social') {
+    } else if (component === 'p-link' || component === 'p-link-pure' || component === 'p-link-social'  || component === 'p-crest') {
       props = addUxPinIgnorePropAnnotation(props, 'href');
+      props = addUxPinIgnorePropAnnotation(props, 'target');
     }
 
     // add uxpinbind annotations
@@ -270,6 +272,22 @@ export class UXPinReactWrapperGenerator extends ReactWrapperGenerator {
             '    }',
             '    useEventCallback(elementRef, \'dismiss\', dismissCallback);',
           ].join('\n')
+      )
+    }
+
+    // make crest link if onClick is defined
+    if (component === 'p-crest') {
+      cleanedComponent = cleanedComponent.replace(
+          'const props = {',
+          [
+            '',
+            'useBrowserLayoutEffect(() => {',
+            '  const { current } = elementRef;',
+            '  (current as any).href = rest.onClick ? \'#\' : undefined;',
+            '}, [rest.onClick]);',
+            '',
+            'const props = {',
+          ].join('\n    ')
       )
     }
 
@@ -605,6 +623,7 @@ export default <${formComponentName} ${stringifiedProps} />;
       {
         name: 'Dummy',
         include: [
+         'src/dummy/DummyButton.tsx',
          'src/dummy/DummyImg.tsx',
          'src/dummy/DummyLink.tsx',
          'src/dummy/DummySpan.tsx',

--- a/packages/components/scripts/wrapper-generator/UXPinReactWrapperGenerator.ts
+++ b/packages/components/scripts/wrapper-generator/UXPinReactWrapperGenerator.ts
@@ -4,7 +4,6 @@ import { ReactWrapperGenerator } from './ReactWrapperGenerator';
 import type { ExtendedProp } from './DataStructureBuilder';
 import type { AdditionalFile } from './AbstractWrapperGenerator';
 import { kebabCase, pascalCase } from 'latest-change-case';
-import {useBrowserLayoutEffect} from "../../../components-react/projects/uxpin-wrapper/src/hooks";
 
 type PresetsProps = { [key: string]: number | string | boolean | string[] | object | null };
 

--- a/packages/components/scripts/wrapper-generator/UXPinReactWrapperGenerator.ts
+++ b/packages/components/scripts/wrapper-generator/UXPinReactWrapperGenerator.ts
@@ -276,8 +276,8 @@ export class UXPinReactWrapperGenerator extends ReactWrapperGenerator {
       )
     }
 
-    // make crest link if onClick is defined
-    if (component === 'p-crest') {
+    // make crest and link-pure anchor if onClick is defined
+    if (component === 'p-crest' || component === 'p-link-pure') {
       cleanedComponent = cleanedComponent.replace(
           'const props = {',
           [


### PR DESCRIPTION
… it is used in Tabs Bar

### Pull Request Checklist

<!-- Make sure to read and accept the CLA, before you open the pull request: `CONTRIBUTOR_LICENSE_AGREEMENT` -->
<!-- Tick the checkbox in case you accept it (`[x]`) -->

- [x] I have read and accept the [Contributor License Agreement](https://opensource.porsche.com/docs/cla)

#### References

- Crest/Link/Link Pure: No default href and click event if not defined. Should be set manually using props

- Tabsbar not working and breaking prototype

#### Scope

I added onClick property to crest. When onClick is defined I set href to '#' to make crest link

For link and link pure I did nothing  as click event is added and href is ignored.

Additionally, I hide `target` property as this does not work when we use onClick.

For TabsBar I had to bring back DummyButton as this component used this in preset so I can't hide it.



https://github.com/user-attachments/assets/079900a8-910f-4ff3-aa5b-69b5226796d7





