### PR TITLE
add presets for some components, ignore properties, handle dismiss ev…

### DIFF
--- a/packages/components-react/projects/uxpin-wrapper/src/dummy/DummyDiv.tsx
+++ b/packages/components-react/projects/uxpin-wrapper/src/dummy/DummyDiv.tsx
@@ -2,20 +2,10 @@ import { MouseEvent, PropsWithChildren, useEffect, useRef } from 'react';
 
 type Props = {
   onClick?: (e: MouseEvent) => void;
-  /**
-   * @uxpincontroltype textfield(4)
-   */
-  inlineStyle?: string;
 };
 
 export const DummyDiv = ({ children = 'DummyDiv', inlineStyle, ...rest }: PropsWithChildren<Props>): JSX.Element => {
   const elementRef = useRef<HTMLDivElement>();
-
-  useEffect(() => {
-    // fighting the framework
-    elementRef.current.setAttribute('style', inlineStyle);
-  }, [inlineStyle]);
-
   const props = { ...rest, children };
 
   return <div ref={elementRef} {...props} />;

--- a/packages/components/scripts/wrapper-generator/UXPinReactWrapperGenerator.ts
+++ b/packages/components/scripts/wrapper-generator/UXPinReactWrapperGenerator.ts
@@ -398,7 +398,6 @@ export class UXPinReactWrapperGenerator extends ReactWrapperGenerator {
       },
       'p-checkbox': {
         props: { label: 'label' },
-        children: '<DummyCheckbox uxpId="dummy-checkbox" />',
       },
       'p-fieldset': {
         props: { label: 'Fieldset' },

--- a/packages/components/scripts/wrapper-generator/UXPinReactWrapperGenerator.ts
+++ b/packages/components/scripts/wrapper-generator/UXPinReactWrapperGenerator.ts
@@ -301,22 +301,7 @@ export class UXPinReactWrapperGenerator extends ReactWrapperGenerator {
           ].join('\n')
       )
     }
-
-    // make crest and link-pure anchor if onClick is defined
-    if (component === 'p-crest' || component === 'p-link-pure') {
-      cleanedComponent = cleanedComponent.replace(
-          'const props = {',
-          [
-            '',
-            'useBrowserLayoutEffect(() => {',
-            '  const { current } = elementRef;',
-            '  (current as any).href = rest.onClick ? \'#\' : undefined;',
-            '}, [rest.onClick]);',
-            '',
-            'const props = {',
-          ].join('\n    ')
-      )
-    }
+    
     // cast BreakpointCustomizable default prop values to any because BreakpointCustomizable types are removed for uxpin
     extendedProps
       .filter((prop) => prop.isDefaultValueComplex && prop.defaultValue.match(/\bbase\b/))

--- a/packages/components/scripts/wrapper-generator/UXPinReactWrapperGenerator.ts
+++ b/packages/components/scripts/wrapper-generator/UXPinReactWrapperGenerator.ts
@@ -301,7 +301,7 @@ export class UXPinReactWrapperGenerator extends ReactWrapperGenerator {
           ].join('\n')
       )
     }
-    
+
     // cast BreakpointCustomizable default prop values to any because BreakpointCustomizable types are removed for uxpin
     extendedProps
       .filter((prop) => prop.isDefaultValueComplex && prop.defaultValue.match(/\bbase\b/))
@@ -409,7 +409,7 @@ export class UXPinReactWrapperGenerator extends ReactWrapperGenerator {
         props: { heading: 'Heading', open: true },
         children: [
           '<Text uxpId="modal-text">Some Content</Text>',
-          '<ButtonGroup uxpId="modal-button-group" >',
+          '<ButtonGroup slot="footer" uxpId="modal-button-group" >',
           ...[
             '<Button uxpId="modal-button-1" children="Save" />',
             '<Button uxpId="modal-button-2" variant="tertiary" children="Close" />',

--- a/packages/components/scripts/wrapper-generator/UXPinReactWrapperGenerator.ts
+++ b/packages/components/scripts/wrapper-generator/UXPinReactWrapperGenerator.ts
@@ -144,6 +144,21 @@ export class UXPinReactWrapperGenerator extends ReactWrapperGenerator {
       props = addUxPinIgnorePropAnnotation(props, 'open');
     } else if (component === 'p-link' || component === 'p-link-pure' || component === 'p-link-social') {
       props = addUxPinIgnorePropAnnotation(props, 'href');
+<<<<<<< Updated upstream
+=======
+      props = addUxPinIgnorePropAnnotation(props, 'target');
+    } else if (component === 'p-banner') {
+      props = addUxPinIgnorePropAnnotation(props, 'width');
+    } else if (component === 'p-button' || component === 'p-button-pure') {
+      props = addUxPinIgnorePropAnnotation(props, 'name');
+      props = addUxPinIgnorePropAnnotation(props, 'value');
+    } else if (component === 'p-icon') {
+      props = addUxPinIgnorePropAnnotation(props, 'lazy');
+    } else if (component === 'p-model-signature') {
+      props = addUxPinIgnorePropAnnotation(props, 'fetchPriority');
+      props = addUxPinIgnorePropAnnotation(props, 'lazy');
+
+>>>>>>> Stashed changes
     }
 
     // add uxpinbind annotations
@@ -260,7 +275,7 @@ export class UXPinReactWrapperGenerator extends ReactWrapperGenerator {
       )
     }
 
-    if (component === 'p-flyout') {
+    if (['p-flyout', 'p-modal', 'p-banner'].includes(component)) {
       cleanedComponent = cleanedComponent.replace(
           'useEventCallback(elementRef, \'dismiss\', onDismiss as any);',
           [
@@ -275,6 +290,40 @@ export class UXPinReactWrapperGenerator extends ReactWrapperGenerator {
       )
     }
 
+<<<<<<< Updated upstream
+=======
+    if (component === 'p-inline-notification') {
+      cleanedComponent = cleanedComponent.replace(
+          'useEventCallback(elementRef, \'dismiss\', onDismiss as any);',
+          [
+            'const dismissCallback = (e:Event) => {',
+            '       rest.uxpinOnChange(\`visible\`, \'hidden\', \'stateIa\');',
+            '       if (onDismiss) {',
+            '         onDismiss(e as CustomEvent<void>);',
+            '       }',
+            '    }',
+            '    useEventCallback(elementRef, \'dismiss\', dismissCallback);',
+          ].join('\n')
+      )
+    }
+
+    // make crest and link-pure anchor if onClick is defined
+    if (component === 'p-crest' || component === 'p-link-pure') {
+      cleanedComponent = cleanedComponent.replace(
+          'const props = {',
+          [
+            '',
+            'useBrowserLayoutEffect(() => {',
+            '  const { current } = elementRef;',
+            '  (current as any).href = rest.onClick ? \'#\' : undefined;',
+            '}, [rest.onClick]);',
+            '',
+            'const props = {',
+          ].join('\n    ')
+      )
+    }
+
+>>>>>>> Stashed changes
     // cast BreakpointCustomizable default prop values to any because BreakpointCustomizable types are removed for uxpin
     extendedProps
       .filter((prop) => prop.isDefaultValueComplex && prop.defaultValue.match(/\bbase\b/))
@@ -288,9 +337,10 @@ export class UXPinReactWrapperGenerator extends ReactWrapperGenerator {
   public shouldGenerateFolderPerComponent(component: TagName): boolean {
     switch (component) {
       case 'p-accordion':
+      case 'p-banner':
       case 'p-button-group':
       case 'p-button-tile':
-      case 'p-checkbox-wrapper':
+      case 'p-checkbox':
       case 'p-fieldset':
       case 'p-link-tile':
       case 'p-link-tile-model-signature':
@@ -327,6 +377,9 @@ export class UXPinReactWrapperGenerator extends ReactWrapperGenerator {
         props: { heading: 'Heading' },
         children: '<Text uxpId="accordion-text" children="Content" />',
       },
+      'p-banner': {
+        props: { heading: 'Heading', description: 'Description', open: true, },
+      },
       'p-button-group': {
         children: [
           '<Button variant="primary" uxpId="button-primary" />',
@@ -337,8 +390,8 @@ export class UXPinReactWrapperGenerator extends ReactWrapperGenerator {
         props: { label: 'Some label', description: 'Some description' },
         children: '<DummyImg uxpId="dummy-img" />',
       },
-      'p-checkbox-wrapper': {
-        props: { label: 'CheckboxWrapper' },
+      'p-checkbox': {
+        props: { label: 'label' },
         children: '<DummyCheckbox uxpId="dummy-checkbox" />',
       },
       'p-fieldset': {

--- a/packages/components/scripts/wrapper-generator/UXPinReactWrapperGenerator.ts
+++ b/packages/components/scripts/wrapper-generator/UXPinReactWrapperGenerator.ts
@@ -318,6 +318,7 @@ export class UXPinReactWrapperGenerator extends ReactWrapperGenerator {
       case 'p-banner':
       case 'p-button-group':
       case 'p-button-tile':
+      case 'p-carousel':
       case 'p-checkbox':
       case 'p-fieldset':
       case 'p-link-tile':
@@ -367,6 +368,17 @@ export class UXPinReactWrapperGenerator extends ReactWrapperGenerator {
       'p-button-tile': {
         props: { label: 'Some label', description: 'Some description' },
         children: '<DummyImg uxpId="dummy-img" />',
+      },
+      'p-carousel': {
+        props: { heading: 'Some heading' },
+        children: [
+          '<DummyDiv uxpId="dummy-div-1" uxpinCustomStyles={{ display: \'flex\', alignItems: \'center\', justifyContent: \'center\', background: \'#00b0f4\', height: 150 }} children="Slide 1" />',
+          '<DummyDiv uxpId="dummy-div-2" uxpinCustomStyles={{ display: \'flex\', alignItems: \'center\', justifyContent: \'center\', background: \'#00b0f4\', height: 150 }}  children="Slide 2" />',
+          '<DummyDiv uxpId="dummy-div-3" uxpinCustomStyles={{ display: \'flex\', alignItems: \'center\', justifyContent: \'center\', background: \'#00b0f4\', height: 150 }}  children="Slide 3" />',
+          '<DummyDiv uxpId="dummy-div-4" uxpinCustomStyles={{ display: \'flex\', alignItems: \'center\', justifyContent: \'center\', background: \'#00b0f4\', height: 150 }}  children="Slide 4" />',
+          '<DummyDiv uxpId="dummy-div-5" uxpinCustomStyles={{ display: \'flex\', alignItems: \'center\', justifyContent: \'center\', background: \'#00b0f4\', height: 150 }}  children="Slide 5" />',
+
+        ].join(glue),
       },
       'p-checkbox': {
         props: { label: 'label' },

--- a/packages/components/scripts/wrapper-generator/UXPinReactWrapperGenerator.ts
+++ b/packages/components/scripts/wrapper-generator/UXPinReactWrapperGenerator.ts
@@ -144,8 +144,6 @@ export class UXPinReactWrapperGenerator extends ReactWrapperGenerator {
       props = addUxPinIgnorePropAnnotation(props, 'open');
     } else if (component === 'p-link' || component === 'p-link-pure' || component === 'p-link-social') {
       props = addUxPinIgnorePropAnnotation(props, 'href');
-<<<<<<< Updated upstream
-=======
       props = addUxPinIgnorePropAnnotation(props, 'target');
     } else if (component === 'p-banner') {
       props = addUxPinIgnorePropAnnotation(props, 'width');
@@ -158,7 +156,6 @@ export class UXPinReactWrapperGenerator extends ReactWrapperGenerator {
       props = addUxPinIgnorePropAnnotation(props, 'fetchPriority');
       props = addUxPinIgnorePropAnnotation(props, 'lazy');
 
->>>>>>> Stashed changes
     }
 
     // add uxpinbind annotations
@@ -290,8 +287,6 @@ export class UXPinReactWrapperGenerator extends ReactWrapperGenerator {
       )
     }
 
-<<<<<<< Updated upstream
-=======
     if (component === 'p-inline-notification') {
       cleanedComponent = cleanedComponent.replace(
           'useEventCallback(elementRef, \'dismiss\', onDismiss as any);',
@@ -322,8 +317,6 @@ export class UXPinReactWrapperGenerator extends ReactWrapperGenerator {
           ].join('\n    ')
       )
     }
-
->>>>>>> Stashed changes
     // cast BreakpointCustomizable default prop values to any because BreakpointCustomizable types are removed for uxpin
     extendedProps
       .filter((prop) => prop.isDefaultValueComplex && prop.defaultValue.match(/\bbase\b/))


### PR DESCRIPTION
…ents

### Pull Request Checklist

<!-- Make sure to read and accept the CLA, before you open the pull request: `CONTRIBUTOR_LICENSE_AGREEMENT` -->
<!-- Tick the checkbox in case you accept it (`[x]`) -->

- [x] I have read and accept the [Contributor License Agreement](https://opensource.porsche.com/docs/cla)

#### References

Optimize Props / Preconfig for UX Pin (Designer)
- Generally hide all events in props panel as they are available in interactions: e.g. close, dismiss, update, blur, action
- Banner: Hide width prop (deprecated), Set prop open to true, add "heading" and "description as predefined value to props
- Button/ButtonPure: Hide props name and value
- Checkbox: Add "label" as predefined value for label
- Icon: Hide lazy prop
- ModelSignature: Hide lazy and fetch priority prop
-Predefine close events in component as interaction to close it
- Currently the Modal in UX Pin does not have paddings / grid for spacing between text and button group like the code example: https://designsystem.porsche.com/v3/components/modal/examples
- If possible provide a predefined component to represent a working example for carousel, like https://designsystem.porsche.com/v3/components/carousel/examples#width

#### Scope

- Generally hide all events in props panel as they are available in interactions: e.g. close, dismiss, update, blur, action ❌  **I can't do this at this moment. it's connected. If I hide them in props panel they won't be available in interactions panel**
- Banner: Hide width prop (deprecated), Set prop open to true, add "heading" and "description as predefined value to props ✅ 
- Button/ButtonPure: Hide props name and value ✅ 
- Checkbox: Add "label" as predefined value for label ✅ 
- Icon: Hide lazy prop ✅ 
- ModelSignature: Hide lazy and fetch priority prop ✅ 
-Predefine close events in component as interaction to close it ✅  **I handled it for
  modal, flyout, banner and inner-notification (for inner-notification I have just hide element because it does not have open property)**
- Currently the Modal in UX Pin does not have paddings / grid for spacing between text and button group like the code example: https://designsystem.porsche.com/v3/components/modal/examples ✅
- If possible provide a predefined component to represent a working example for carousel, like https://designsystem.porsche.com/v3/components/carousel/examples#width ✅

