### PR TITLE
[FEATURE]: Add out of the box behavior to p-accordion 

### DIFF
--- a/packages/components/src/components/accordion/accordion.examples.md
+++ b/packages/components/src/components/accordion/accordion.examples.md
@@ -3,8 +3,7 @@
 The `p-accordion` is a component that reveals or hides associated sections of content.  
 Accordions are flexible in the context and can include other components of the Porsche Design System.
 
-It is a controlled component. This means it does not contain any internal state, and you got full control over its
-behavior.
+It is an optionally controlled component. This means it does contain internal state, which allows for out-of-the-box open/close functionality. Using the `open` prop and `update` event also expose full control over its behavior.
 
 <TableOfContents></TableOfContents>
 


### PR DESCRIPTION
### Pull Request Checklist

<!-- Make sure to read and accept the CLA, before you open the pull request: `CONTRIBUTOR_LICENSE_AGREEMENT` -->
<!-- Tick the checkbox in case you accept it (`[x]`) -->

- [x] I have read and accept the [Contributor License Agreement](https://opensource.porsche.com/docs/cla)

#### References

- Preview: https://designsystem.porsche.com/issue/3549/components/accordion/examples

#### Scope

- adds an internal open/close state to the `accordion` component so that it can be toggled without a parent component passing the `open` prop

#### Resolved Issue

Resolves [#2533](https://github.com/porsche-design-system/porsche-design-system/issues/2533)
