### PR TITLE
housekeeping(storefront): update mdx components

### DIFF
--- a/packages/storefront/src/app/license/page.mdx
+++ b/packages/storefront/src/app/license/page.mdx
@@ -23,15 +23,12 @@ reserves the right to change and update this licensing agreement at any time.
 ## General Notices
 
 Further information regarding license terms and – where required by license – source codes are available at
-
-<PLinkPure icon="none" target="_blank" href="https://porsche.com/softwareinfo">
-  www.porsche.com/softwareinfo
-</PLinkPure>
+{/* prettier-ignore */}
+<PLinkPure icon="none" target="_blank" href="https://porsche.com/softwareinfo">www.porsche.com/softwareinfo</PLinkPure>
 free of charge. Some licenses, however, require the provision of physical copies of source or object code. In this case,
 you may obtain a copy of the source codes by contacting us at
-<PLinkPure icon="none" target="_blank" href="https://porsche.com/softwareinfo">
-  www.porsche.com/softwareinfo
-</PLinkPure>
+{/* prettier-ignore */}
+<PLinkPure icon="none" target="_blank" href="https://porsche.com/softwareinfo">www.porsche.com/softwareinfo</PLinkPure>
 . Furthermore, please contact us at the foregoing URL in case you need assistance regarding the exercise of rights
 guaranteed by an Open Source License. A nominal fee (i.e., the cost of physically performing the distribution) will be
 charged for these services.
@@ -42,7 +39,5 @@ on the exact product and version you choose.
 ## Open Source Software Notice
 
 This software may or may not contain the following specific Open Source Software:
-
-<PLinkPure icon="download" href="assets/compulsory-statement.txt" download="compulsory-statement.txt">
-  Download Compulsory Statement
-</PLinkPure>
+{/* prettier-ignore */}
+<PLinkPure icon="download" href="assets/compulsory-statement.txt" download="compulsory-statement.txt">Download Compulsory Statement</PLinkPure>

--- a/packages/storefront/src/app/news/roadmap/page.mdx
+++ b/packages/storefront/src/app/news/roadmap/page.mdx
@@ -17,9 +17,8 @@ new requirements.
 
 More details about the actual backlog and work in progress can be found in the Porsche Design System project board:
 
-<PLink href="https://github.com/orgs/porsche-design-system/projects/14" target="_blank">
-  Open Project Board
-</PLink>
+{/* prettier-ignore */}
+<PLink href="https://github.com/orgs/porsche-design-system/projects/14" target="_blank">Open Project Board</PLink>
 
 ## Milestones in Progress
 

--- a/packages/storefront/src/app/patterns/ai-tag/page.mdx
+++ b/packages/storefront/src/app/patterns/ai-tag/page.mdx
@@ -18,9 +18,11 @@ the presence of **"AI-generated"** or **"AI-modified"** contents within the appl
 
 <div className="flex flex-wrap gap-static-md">
   <PLinkPure icon="external">
+    {/* prettier-ignore */}
     <Link href="https://github.com/porsche-design-system/examples/tree/main/patterns/src/ai-tag/1">Source Code</Link>
   </PLinkPure>
   <PLinkPure icon="external">
+    {/* prettier-ignore */}
     <Link href="https://porsche-design-system.github.io/examples/patterns/ai-tag/1">View Fullscreen</Link>
   </PLinkPure>
 </div>

--- a/packages/storefront/src/app/patterns/footer/page.mdx
+++ b/packages/storefront/src/app/patterns/footer/page.mdx
@@ -17,9 +17,11 @@ information regardless of their location on the site.
 
 <div className="flex flex-wrap gap-static-md mt-fluid-lg">
   <PLinkPure icon="external">
+    {/* prettier-ignore */}
     <Link href="https://github.com/porsche-design-system/examples/tree/main/patterns/src/footer/1">Source Code</Link>
   </PLinkPure>
   <PLinkPure icon="external">
+    {/* prettier-ignore */}
     <Link href="https://porsche-design-system.github.io/examples/patterns/footer/1">View Fullscreen</Link>
   </PLinkPure>
 </div>

--- a/packages/storefront/src/app/patterns/header/page.mdx
+++ b/packages/storefront/src/app/patterns/header/page.mdx
@@ -21,9 +21,11 @@ efficient user journey.
 
 <div className="flex flex-wrap gap-static-md">
   <PLinkPure icon="external">
+    {/* prettier-ignore */}
     <Link href="https://github.com/porsche-design-system/examples/tree/main/patterns/src/header/1">Source Code</Link>
   </PLinkPure>
   <PLinkPure icon="external">
+    {/* prettier-ignore */}
     <Link href="https://porsche-design-system.github.io/examples/patterns/header/1">View Fullscreen</Link>
   </PLinkPure>
 </div>
@@ -38,9 +40,11 @@ efficient user journey.
 
 <div className="flex flex-wrap gap-static-md">
   <PLinkPure icon="external">
+    {/* prettier-ignore */}
     <Link href="https://github.com/porsche-design-system/examples/tree/main/patterns/src/header/2">Source Code</Link>
   </PLinkPure>
   <PLinkPure icon="external">
+    {/* prettier-ignore */}
     <Link href="https://porsche-design-system.github.io/examples/patterns/header/2">View Fullscreen</Link>
   </PLinkPure>
 </div>

--- a/packages/storefront/src/app/patterns/notifications/introduction/page.mdx
+++ b/packages/storefront/src/app/patterns/notifications/introduction/page.mdx
@@ -23,6 +23,7 @@ using your product. Ensure your **notifications are relevant, timely, and inform
 In order to find the right notification type for your use case, we have defined some decision-making rules for you:
 
 <PLink>
+  {/* prettier-ignore */}
   <Link href="/patterns/notifications/decision-tree/">Go to the Decision Tree</Link>
 </PLink>
 

--- a/packages/storefront/src/app/templates/landing-page/page.mdx
+++ b/packages/storefront/src/app/templates/landing-page/page.mdx
@@ -23,6 +23,7 @@ or registering for an event.
     <Link href="https://github.com/porsche-design-system/examples/tree/main/templates/src/landing-page/1">Source Code</Link>
   </PLinkPure>
   <PLinkPure icon="external">
+    {/* prettier-ignore */}
     <Link href="https://porsche-design-system.github.io/examples/templates/landing-page/1">View Fullscreen</Link>
   </PLinkPure>
 </div>


### PR DESCRIPTION
…on increment | ks | #housekeeping

### Pull Request Checklist

<!-- Make sure to read and accept the CLA, before you open the pull request: `CONTRIBUTOR_LICENSE_AGREEMENT` -->
<!-- Tick the checkbox in case you accept it (`[x]`) -->

- [x] I have read and accept the [Contributor License Agreement](https://opensource.porsche.com/docs/cla)

#### References

- Preview: https://designsystem.porsche.com/issue/.../

#### Scope

My assumption is, that the `@next/mdx` package wraps all text which is not wrapped in a `html` tag  in the same line automatically in `<p></p>`. 

In our`mdx-components.tsx` (https://nextjs.org/docs/app/guides/mdx#add-an-mdx-componentstsx-file) we have:

```tsx
export const P = ({ children }: PropsWithChildren) => (
  <PText className="my-fluid-sm max-w-(--max-width-prose)">{children}</PText>
);
```

So:

```tsx
<PLink href="https://github.com/orgs/porsche-design-system/projects/14" target="_blank">
  Open Project Board
</PLink>
```

becomes:

```tsx
<PLink href="https://github.com/orgs/porsche-design-system/projects/14" target="_blank">
  <p>Open Project Board</p>
</PLink>
```

and is then transformed into:

```tsx
<PLink href="https://github.com/orgs/porsche-design-system/projects/14" target="_blank">
  <PText className="my-fluid-sm max-w-(--max-width-prose)">Open Project Board</PText>
</PLink>
```

Solution is:

```tsx
{/* prettier-ignore */}
<PLink href="https://github.com/orgs/porsche-design-system/projects/14" target="_blank">Open Project Board</PLink>
```
or

```tsx
<PLink href="https://github.com/orgs/porsche-design-system/projects/14" target="_blank">
  <>Open Project Board</>
</PLink>
```
