### PR TITLE
feat(components-js): add exclude option to load()

### DIFF
--- a/packages/components-js/projects/components-manager-cli/library-entry/with-prefix.ts
+++ b/packages/components-js/projects/components-manager-cli/library-entry/with-prefix.ts
@@ -31,10 +31,12 @@ declare var CM_CONFIG: EntryConfig;
 /**
  * @property prefix - the prefix used for the components
  * @property cdn - the cdn to load assets from
+ * @property exclude - tag names to skip during custom element registration (e.g. ['p-table', 'p-select'])
  */
 export type LoadOptions = {
   prefix?: string;
   cdn?: 'auto' | 'cn';
+  exclude?: string[];
 };
 
 export const load = (opts: LoadOptions = {}): void => {
@@ -58,5 +60,5 @@ export const load = (opts: LoadOptions = {}): void => {
     prefixes: [], // to not break older versions
   };
 
-  loadComponentLibrary({ ...CM_CONFIG, prefix: opts.prefix || '' });
+  loadComponentLibrary({ ...CM_CONFIG, prefix: opts.prefix || '', exclude: opts.exclude });
 };

--- a/packages/components-js/projects/components-manager-core/src/services/library-handler.spec.ts
+++ b/packages/components-js/projects/components-manager-core/src/services/library-handler.spec.ts
@@ -275,3 +275,9 @@ it('should keep exclude empty when not provided', () => {
   loadComponentLibrary({ ...defaultOptions, version: '1.0.0' });
   expect(getComponentsManagerData()['1.0.0'].exclude).toEqual([]);
 });
+
+it('should not mutate exclude list when prefix collision throws', () => {
+  loadComponentLibrary({ ...defaultOptions, version: '1.0.0' });
+  expect(() => loadComponentLibrary({ ...defaultOptions, version: '1.1.0', exclude: ['p-table'] })).toThrow();
+  expect(getComponentsManagerData()['1.1.0'].exclude).toEqual([]);
+});

--- a/packages/components-js/projects/components-manager-core/src/services/library-handler.spec.ts
+++ b/packages/components-js/projects/components-manager-core/src/services/library-handler.spec.ts
@@ -52,6 +52,7 @@ it('should load the library for each version once if version and prefix is used'
           "",
         ],
         "readyResolve": [Function],
+        "exclude": [],
         "registerCustomElements": null,
       },
     }
@@ -68,6 +69,7 @@ it('should load the library for each version once if version and prefix is used'
           "",
         ],
         "readyResolve": [Function],
+        "exclude": [],
         "registerCustomElements": null,
       },
       "2.0.0": {
@@ -77,6 +79,7 @@ it('should load the library for each version once if version and prefix is used'
           "some-prefix",
         ],
         "readyResolve": [Function],
+        "exclude": [],
         "registerCustomElements": null,
       },
     }
@@ -94,6 +97,7 @@ it('should load the library for each version once if version and prefix is used'
           "my-prefix",
         ],
         "readyResolve": [Function],
+        "exclude": [],
         "registerCustomElements": null,
       },
       "2.0.0": {
@@ -103,6 +107,7 @@ it('should load the library for each version once if version and prefix is used'
           "some-prefix",
         ],
         "readyResolve": [Function],
+        "exclude": [],
         "registerCustomElements": null,
       },
     }
@@ -120,6 +125,7 @@ it('should load the library for each version once if version and prefix is used'
           "my-prefix",
         ],
         "readyResolve": [Function],
+        "exclude": [],
         "registerCustomElements": null,
       },
       "2.0.0": {
@@ -130,6 +136,7 @@ it('should load the library for each version once if version and prefix is used'
           "another-prefix",
         ],
         "readyResolve": [Function],
+        "exclude": [],
         "registerCustomElements": null,
       },
     }
@@ -193,6 +200,7 @@ it('should throw if prefix is already used by different version', () => {
           "",
         ],
         "readyResolve": [Function],
+        "exclude": [],
         "registerCustomElements": null,
       },
     }
@@ -211,6 +219,7 @@ it('should throw if prefix is already used by different version', () => {
           "",
         ],
         "readyResolve": [Function],
+        "exclude": [],
         "registerCustomElements": null,
       },
       "1.1.0": {
@@ -218,6 +227,7 @@ it('should throw if prefix is already used by different version', () => {
         "isReady": [Function],
         "prefixes": [],
         "readyResolve": [Function],
+        "exclude": [],
         "registerCustomElements": null,
       },
     }
@@ -233,6 +243,7 @@ it('should throw if prefix is already used by different version', () => {
           "",
         ],
         "readyResolve": [Function],
+        "exclude": [],
         "registerCustomElements": null,
       },
       "1.1.0": {
@@ -242,8 +253,25 @@ it('should throw if prefix is already used by different version', () => {
           "prefixed",
         ],
         "readyResolve": [Function],
+        "exclude": [],
         "registerCustomElements": null,
       },
     }
   `);
+});
+
+it('should store exclude list in version data', () => {
+  loadComponentLibrary({ ...defaultOptions, version: '1.0.0', exclude: ['p-table', 'p-scroller'] });
+  expect(getComponentsManagerData()['1.0.0'].exclude).toEqual(['p-table', 'p-scroller']);
+});
+
+it('should merge exclude lists from multiple load calls without duplicates', () => {
+  loadComponentLibrary({ ...defaultOptions, version: '1.0.0', exclude: ['p-table'] });
+  loadComponentLibrary({ ...defaultOptions, version: '1.0.0', prefix: 'my', exclude: ['p-table', 'p-select'] });
+  expect(getComponentsManagerData()['1.0.0'].exclude).toEqual(['p-table', 'p-select']);
+});
+
+it('should keep exclude empty when not provided', () => {
+  loadComponentLibrary({ ...defaultOptions, version: '1.0.0' });
+  expect(getComponentsManagerData()['1.0.0'].exclude).toEqual([]);
 });

--- a/packages/components-js/projects/components-manager-core/src/services/library-handler.ts
+++ b/packages/components-js/projects/components-manager-core/src/services/library-handler.ts
@@ -9,6 +9,7 @@ export type LibraryHandlerData = {
   isReady: () => Promise<unknown>;
   readyResolve: ReadyResolve;
   prefixes: string[];
+  exclude: string[];
   registerCustomElements: RegisterCustomElementsCallback | null;
 };
 
@@ -21,12 +22,22 @@ export type LoadComponentLibraryOptions = {
   script: string;
   version: string;
   prefix: string;
+  exclude?: string[];
 };
 /**
  * @param options - LoadComponentLibraryOptions
  */
-export function loadComponentLibrary({ script, version, prefix }: LoadComponentLibraryOptions): void {
+export function loadComponentLibrary({ script, version, prefix, exclude = [] }: LoadComponentLibraryOptions): void {
   const data = getLibraryHandlerData(version as `${number}.${number}.${number}`);
+
+  if (exclude.length) {
+    for (const tag of exclude) {
+      if (!data.exclude.includes(tag)) {
+        data.exclude.push(tag);
+      }
+    }
+  }
+
   const { isInjected, prefixes = [], registerCustomElements } = data;
 
   const [collidingVersion] = Object.entries(getComponentsManagerData()).filter(
@@ -82,6 +93,7 @@ function getLibraryHandlerData(version: `${number}.${number}.${number}`): Librar
       isReady: () => readyPromise,
       readyResolve: readyPromiseResolve,
       prefixes: [],
+      exclude: [],
       registerCustomElements: null,
     };
   }

--- a/packages/components-js/projects/components-manager-core/src/services/library-handler.ts
+++ b/packages/components-js/projects/components-manager-core/src/services/library-handler.ts
@@ -29,15 +29,6 @@ export type LoadComponentLibraryOptions = {
  */
 export function loadComponentLibrary({ script, version, prefix, exclude = [] }: LoadComponentLibraryOptions): void {
   const data = getLibraryHandlerData(version as `${number}.${number}.${number}`);
-
-  if (exclude.length) {
-    for (const tag of exclude) {
-      if (!data.exclude.includes(tag)) {
-        data.exclude.push(tag);
-      }
-    }
-  }
-
   const { isInjected, prefixes = [], registerCustomElements } = data;
 
   const [collidingVersion] = Object.entries(getComponentsManagerData()).filter(
@@ -48,6 +39,14 @@ export function loadComponentLibrary({ script, version, prefix, exclude = [] }: 
       `[Porsche Design System v${version}] prefix '${prefix}' is already registered with version '${collidingVersion[0]}' of the Porsche Design System. Please use a different one.
 Take a look at document.${CM_KEY} for more details.`
     );
+  }
+
+  if (exclude.length) {
+    for (const tag of exclude) {
+      if (!data.exclude.includes(tag)) {
+        data.exclude.push(tag);
+      }
+    }
   }
 
   if (!isInjected) {

--- a/packages/components-js/projects/components-wrapper/src/index.js
+++ b/packages/components-js/projects/components-wrapper/src/index.js
@@ -1,10 +1,16 @@
 import { defineCustomElements } from '@porsche-design-system/components/dist/esm/loader-cleaned';
 import { setRegisterComponentsCallback } from '@porsche-design-system/components-manager-core';
 
+const CM_KEY = 'porscheDesignSystem';
+
 setRegisterComponentsCallback(
-  (prefix) =>
+  (prefix) => {
+    const versionData = document[CM_KEY]?.[PORSCHE_DESIGN_SYSTEM_VERSION];
+    const exclude = versionData?.exclude || [];
     defineCustomElements({
       transformTagName: (tagName) => (prefix ? `${prefix}-${tagName}` : tagName),
-    }),
+      exclude,
+    });
+  },
   PORSCHE_DESIGN_SYSTEM_VERSION
 );


### PR DESCRIPTION
### Pull Request Checklist

- [x] I have read and accept the [Contributor License Agreement](https://opensource.porsche.com/docs/cla)

#### References

- Related issue: #4457

#### Scope

Expose the existing `exclude` array from Stencil's `bootstrapLazy()` through the public `load()` API. Consumers can prevent PDS from registering specific custom elements that collide with third-party libraries (PrimeNG, Ionic, Shoelace).

PDS uses the `p-` prefix. PrimeNG uses identical selectors (`p-table`, `p-select`, `p-checkbox`, etc.) that are hardcoded and cannot be changed. When PDS registers these tags first, it wraps them in Shadow DOM and breaks PrimeNG's light-DOM rendering. 16 tag names collide today.

Stencil already has the mechanism internally:

```javascript
// bootstrapLazy() in the generated bundle
const exclude = options.exclude || [];
if (!exclude.includes(tagName) && !customElements2.get(tagName)) {
  customElements2.define(tagName, proxyComponent(...));
}
```

This PR pipes `exclude` from `load()` through `loadComponentLibrary()` and the CDN script entry point into `defineCustomElements()`, where it reaches `bootstrapLazy()`.

Consumer usage after this change:

```typescript
load({ exclude: ['p-table', 'p-scroller', 'p-select', 'p-checkbox'] });
```

Changes in 3 files:

- `components-manager-core/src/services/library-handler.ts` - add `exclude: string[]` to types, store and merge in version data
- `components-manager-cli/library-entry/with-prefix.ts` - add `exclude?: string[]` to `LoadOptions`, pass through
- `components-wrapper/src/index.js` - read `exclude` from version data in the `setRegisterComponentsCallback`, pass to `defineCustomElements()`

#### Resolved Issue

Resolves #4457