### PR TITLE
Set up Cursor Cloud development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,3 +204,12 @@ When multiple guidance files exist, prefer them in this order:
 | Clean rebuild  | `npm run clean && npm install && npm run build` |
 | Run in Docker  | `./docker.sh {command}`                    |
 
+## Cursor Cloud specific instructions
+
+The startup update script already runs `npm install` (with Node 24 active). Standard build/dev/test commands are documented above; only the non-obvious caveats below matter for this environment.
+
+- **Node version gotcha**: The base VM ships Node 22 at `/exec-daemon/node`, which sits ahead of nvm on `PATH`. The repo requires the Volta-pinned Node 24 (`24.15.0`). Node 24 is installed via nvm and `~/.bashrc` prepends its bin dir so login shells resolve `node` to v24 automatically. If a command unexpectedly runs on Node 22, run `nvm use 24.15.0` (or start a fresh login shell) before retrying.
+- **`npm run build` is long and must precede tests/wrappers/storefront**: The full build (through the storefront `next build`) takes on the order of ~25–30 min and exceeds a single foreground command window — run it in a background tmux session and poll a log file rather than blocking. For component-only work, `npm run build:core-dependencies` is much faster.
+- **Dev servers auto-start mock hosts**: `npm run start:storefront` (Next.js, port `3000`) and `npm run start:components` (Stencil, port `3333`) each also launch a mock CDN on `3001` (and framework demo apps additionally launch dummy-assets on `3002`). No external services/DB are needed. The Vite demo apps all default to port `5173` and both Next.js apps to `3000`, so run conflicting apps one at a time.
+- **VRT tests require Docker** (`./docker.sh npm run test:vrt:components-js`) for consistent screenshots; e2e/a11y tests require a completed build first.
+


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the development environment for the Porsche Design System monorepo in Cursor Cloud. No application code was changed — only `AGENTS.md` gains a `## Cursor Cloud specific instructions` section documenting non-obvious startup caveats for future agents.

## What was done

- Installed the Volta-pinned **Node 24.15.0** via nvm (base VM ships Node 22 at `/exec-daemon/node`, which shadows nvm on `PATH`; fixed via a `~/.bashrc` prepend).
- Ran `npm install` (npm workspaces) and the full `npm run build`.
- Verified lint, unit tests, and the storefront dev server end-to-end.

## Verification

- `npm run lint` — Biome, 2356 files, no issues.
- `npm run test:unit:components` — 4031 passed / 33 skipped.
- `npm run build` — full monorepo build succeeded (exit 0), including the storefront `next build`.
- `npm run start:storefront` — Next.js dev site on `:3000` (HTTP 200); demonstrated the live Button configurator (variant/icon/loading/theme/framework switches update the rendered `p-button` web component in real time).

## Update script (VM startup)

```
export NVM_DIR="$HOME/.nvm"
[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
nvm use 24.15.0 > /dev/null 2>&1 || true
npm install
```

## Demo

[pds_storefront_button_configurator_demo.mp4](https://cursor.com/agents/bc-2c4072a2-19a2-4069-be6c-d6a64dd5c2ab/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpds_storefront_button_configurator_demo.mp4)

[Button configurator](https://cursor.com/agents/bc-2c4072a2-19a2-4069-be6c-d6a64dd5c2ab/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstorefront_button_configurator.webp)
[Dark mode](https://cursor.com/agents/bc-2c4072a2-19a2-4069-be6c-d6a64dd5c2ab/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstorefront_dark_mode.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2c4072a2-19a2-4069-be6c-d6a64dd5c2ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2c4072a2-19a2-4069-be6c-d6a64dd5c2ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

