### PR TITLE
[turbo-spec ENGINE DEMO] weekly-dependency-bump exhausted path - safe to close

### DIFF
--- a/package.json
+++ b/package.json
@@ -304,5 +304,6 @@
   "volta": {
     "node": "24.15.0",
     "npm": "11.12.1"
-  }
+  },
+  "turboSpecDemo": "ENGINE DEMO - safe to close - 2026-07-27T17:28:55.222Z"
 }


### PR DESCRIPTION
Automated turbo-spec ENGINE DEMO / blueprint-validation run from porsche-code/turbo-spec#1398. NOT a real dependency bump. Safe to close. Proves the exhaustion-path terminal genuinely reaches outcome draft_filed after 3 install retries.