### PR TITLE
Change bug report label to 'Kickoff'

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -1,7 +1,7 @@
 name: "🐞 Bug Report"
 description: Create a report to help us improve
 title: "Short description"
-labels: ["community", "to be refined"]
+labels: ["Kickoff"]
 type: bug
 projects: ["porsche-design-system/14"]
 body:


### PR DESCRIPTION
Updated the labels for the bug report template.

### Pull Request Checklist

<!-- Make sure to read and accept the CLA, before you open the pull request: `CONTRIBUTOR_LICENSE_AGREEMENT` -->
<!-- Tick the checkbox in case you accept it (`[x]`) -->

- [ ] I have read and accept the [Contributor License Agreement](https://opensource.porsche.com/docs/cla)

### Related Issue

<!-- Link the issue this PR resolves so it closes automatically on merge. Replace <issue-number>, or remove this section if there is no related issue. -->

Closes #<issue-number>
